### PR TITLE
Adapt _DownloadOnlySubdirData to be compatible with newer conda SubdirData class

### DIFF
--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -311,13 +311,13 @@ class _DownloadOnlySubdirData(SubdirData):
         "_track_features_index": {},
     }
 
-    def _read_local_repdata(self, etag, mod_stamp):
+    def _read_local_repdata(self, *args, **kwargs):
         return self._internal_state_template
 
-    def _process_raw_repodata_str(self, raw_repodata_str):
+    def _process_raw_repodata_str(self, *args, **kwargs):
         return self._internal_state_template
 
-    def _process_raw_repodata(self, repodata):
+    def _process_raw_repodata(self, *args, **kwargs):
         return self._internal_state_template
 
     def _pickle_me(self):

--- a/news/119-breaking-conda-internal-api
+++ b/news/119-breaking-conda-internal-api
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix compatability errors with newer conda versions >=23.1.0 since we are using an internal API SubdirData (#118 via #119)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/119-breaking-conda-internal-api
+++ b/news/119-breaking-conda-internal-api
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix compatability errors with newer conda versions >=23.1.0 since we are using an internal API SubdirData (#118 via #119)
+* Fix compatibility errors with newer conda versions >=23.1.0 since we are using an internal API SubdirData. (#118 via #119)
 
 ### Deprecations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ addopts = [
   # We need conda-forge to release a new Python 3.8.x that defaults has,
   # but a bug in conda-build is preventing feedstocks from operating correctly.
   "--deselect=tests/test_priority.py::PriorityIntegrationTests::test_channel_order_channel_priority_true",
-  # Known 23.1.0 breakage - investigated by costrouc
-  "--deselect=tests/gateways/test_connection.py::test_s3_server",
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",


### PR DESCRIPTION
Closes https://github.com/conda/conda-libmamba-solver/issues/118


### Description

This PR to conda indroduced the compatibility issue https://github.com/conda/conda/pull/12003

Functions `_process_raw_repodata_str` and `_process_raw_repodata` were easy enough to make cross compatible. But `_read_local_repdata` does not have an easy way to make compatible with both versions. The function signatures are:

 - `old` `_read_local_repdata(self, etag, mod_stamp)`
 - `new` `_read_local_repdata(self, state):` https://github.com/conda/conda/blob/main/conda/core/subdir_data.py#L395

The compromise I settled on was to just use `def
_read_local_repdata(self, *args, **kwargs)` instead of adding something that sort of matches the old and new interface.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?
