### PR TITLE
Change build backend from flit to hatchling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ cython_debug/
 
 # rever
 rever/
+
+# setuptools_scm
+_version.py

--- a/conda_libmamba_solver/__init__.py
+++ b/conda_libmamba_solver/__init__.py
@@ -4,7 +4,13 @@
 try:
     from ._version import version as __version__
 except ImportError:
-    __version__ = "0.0.0.unknown"
+    try:
+        from importlib_metadata import version
+
+        __version__ = version("conda_libmamba_solver")
+        del version
+    except ImportError:
+        __version__ = "0.0.0.unknown"
 
 from warnings import warn as _warn
 

--- a/conda_libmamba_solver/__init__.py
+++ b/conda_libmamba_solver/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-__version__ = "22.8.1"
+__version__ = "23.1.0"
 
 from warnings import warn as _warn
 

--- a/conda_libmamba_solver/__init__.py
+++ b/conda_libmamba_solver/__init__.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2022 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-__version__ = "23.1.0"
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "0.0.0.unknown"
 
 from warnings import warn as _warn
 

--- a/dev/bashrc_linux.sh
+++ b/dev/bashrc_linux.sh
@@ -11,12 +11,11 @@ restore_e() {
 trap restore_e EXIT
 
 sudo /opt/conda/condabin/conda install -y -p /opt/conda \
-    "flit-core>=3.2,<4" \
     --file /opt/conda-libmamba-solver-src/dev/requirements.txt \
     --file /opt/conda-libmamba-solver-src/tests/requirements.txt
 
 cd /opt/conda-libmamba-solver-src
-sudo env FLIT_ROOT_INSTALL=1 /opt/conda/bin/python -m flit install --symlink --deps=none
+sudo /opt/conda/bin/python -m pip install -e . --no-deps
 
 cd /opt/conda-src
 export RUNNING_ON_DEVCONTAINER=${RUNNING_ON_DEVCONTAINER:-}

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,4 +1,7 @@
-libmambapy>=1.0
-libarchive
+# build-time
+pip
+# run-time
 conda>=22.9  # should be 22.11
 importlib-metadata
+libarchive
+libmambapy>=1.0

--- a/news/127-hatchling
+++ b/news/127-hatchling
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Change the build-system to `hatchling` + `hatch-cvs` for a `setuptools-scm`-like versioning setup. (#128 via #127)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "conda-libmamba-solver"
@@ -37,8 +37,8 @@ homepage = "https://github.com/conda/conda-libmamba-solver"
 [project.entry-points.conda]
 conda-libmamba-solver = "conda_libmamba_solver.plugin"
 
-[tool.flit.module]
-name = "conda_libmamba_solver"
+[tool.hatch.version]
+source = "vcs"
 
 [tool.black]
 line-length = 99

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: "conda-libmamba-solver"
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: "{{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}"
 
 source:
   # git_url is nice in that it won't capture devenv stuff.  However, it only
@@ -28,6 +28,13 @@ test:
     - conda_libmamba_solver
   commands:
     - CONDA_SOLVER=libmamba conda create -n test --dry-run scipy
+    - >-
+      python -c
+      "import conda_libmamba_solver as cls;
+      from importlib.metadata import version;
+      assert '{{ PKG_VERSION }}' == cls.__version__ == version('conda_libmamba_solver'),
+      '{{ PKG_VERSION }}' + f', {cls.__version__}, ' + version('conda_libmamba_solver')
+      "
 
 about:
   home: https://github.com/conda/conda-libmamba-solver


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

I forgot to update this attribute in the last release, so just fixing it now so it's clear in the future. Internally, `conda-libmamba-solver.__version__` will report `22.8.1` til this is released. To be clear, `conda list` does report the correct version. This now uses `hatchling` plus a setuptools-scm plugin, `hatch-vcs`, as the build backend.