### PR TITLE
Output experimental and non-experimental error messages in the same way

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -611,39 +611,31 @@ class LibMambaSolver(Solver):
 
     def _prepare_problems_message(self):
         if hasattr(self.solver, "explain_problems"):
-            try:
-                raw_problems = self.solver.explain_problems()
-                key = None
-                sections = {}
-                for line in raw_problems.splitlines():
-                    if line.strip().startswith("===="):
-                        title = line.strip("=").strip()
-                        if "(old)" in title:
-                            key = "old"
-                        elif "(new)" in title:
-                            key = "new"
-                        else:
-                            key = "disclaimer"
-                        sections[key] = []
-                        continue
-                    if key is not None:
-                        sections[key].append(line)
-                return "\n".join(
-                    [
-                        *sections["old"],
-                        "",
-                        "***************************************************",
-                        " conda has set experimental_sat_error_message=true",
-                        " You will now see an explanation of the conflicts.",
-                        " You can provide feedback to the libmamba team at:",
-                        "  https://github.com/mamba-org/mamba/issues/2078",
-                        "***************************************************",
-                        "",
-                        *sections["new"],
-                    ]
-                )
-            except Exception as exc:
-                log.debug("Could not parse 'explain_problems'", exc_info=exc)
+            explained_problems = self.solver.explain_problems()
+            if "====" in explained_problems:
+                # This is for libmamba 1.3.x, where the explanation had a disclaimer
+                try:
+                    key = None
+                    sections = {}
+                    for line in explained_problems.splitlines():
+                        if line.strip().startswith("===="):
+                            title = line.strip("=").strip()
+                            if "(old)" in title:
+                                key = "old"
+                            elif "(new)" in title:
+                                key = "new"
+                            else:
+                                key = "disclaimer"
+                            sections[key] = []
+                            continue
+                        if key is not None:
+                            sections[key].append(line)
+                    return "\n".join(sections["old"] + sections["new"])
+                except Exception as exc:
+                    log.debug("Could not parse experimental 'explain_problems'", exc_info=exc)
+            else:
+                # libmamba 1.4.x enabled this by default, no need to parse disclaimers
+                return "\n".join([self.solver.problems_to_str(), explained_problems])
         return self.solver.problems_to_str()
 
     def _maybe_raise_for_conda_build(self, conflicting_specs: Mapping[str, MatchSpec]):

--- a/news/103-exception-parsing
+++ b/news/103-exception-parsing
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Simplify exception parsing and enable new experimental conflict reports in `libmamba`. (#102 via #103)
+* Simplify exception parsing and enable new (experimental) conflict reports in `libmamba`. (#102 via #103, #160)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

libmamba 1.4.0 enabled the experimental error messages by default, so we need to update our approach. See https://github.com/conda/conda-libmamba-solver/pull/103#issuecomment-1481027020.

This PR maintains the compatibility with 1.3.x (disclaimed explanations) and also enables 1.4.x compatibility. We now have the same message format in both versions, with no disclaimer (because the mamba team flipped the switch so no need to explain our decision).

```
$ conda create -n unused --dry-run --solver=libmamba "python=*=*cpython*" pypy
conda-forge/linux-aarch64                                   Using cache
conda-forge/noarch                                          Using cache
Collect all metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides python 3.6.9 1_73_pypy needed by pypy-7.3.1-h9f0ad1d_1

Could not solve for environment specs
The following packages are incompatible
├─ pypy   is installable with the potential options
│  ├─ pypy [7.3.0|7.3.1] would require
│  │  └─ python 3.6.9 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.1 would require
│  │  └─ python 3.6.9 1_73_pypy, which does not exist (perhaps a missing channel);
│  ├─ pypy 7.3.1 would require
│  │  └─ python 3.6.9 2_73_pypy, which can be installed;
│  ├─ pypy 7.3.2 would require
│  │  └─ python 3.6.9 3_73_pypy, which can be installed;
│  ├─ pypy 7.3.3 would require
│  │  └─ python 3.6.12 5_73_pypy, which can be installed;
│  ├─ pypy 7.3.3 would require
│  │  └─ python 3.7.9 5_73_pypy, which can be installed;
│  ├─ pypy 7.3.3 would require
│  │  └─ python 3.6.12 4_73_pypy, which can be installed;
│  ├─ pypy [7.3.4|7.3.5] would require
│  │  └─ python 3.7.10 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.5 would require
│  │  └─ python 3.7.10 1_73_pypy, which can be installed;
│  ├─ pypy 7.3.7 would require
│  │  └─ python 3.7.12 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.8 would require
│  │  └─ python 3.8.12 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.8 would require
│  │  └─ python 3.9.10 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.9 would require
│  │  └─ python 3.8.13 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.9 would require
│  │  └─ python 3.9.12 0_73_pypy, which can be installed;
│  ├─ pypy 7.3.11 would require
│  │  └─ python 3.8.16 0_73_pypy, which can be installed;
│  └─ pypy 7.3.11 would require
│     └─ python 3.9.16 0_73_pypy, which can be installed;
└─ python * *cpython* is uninstallable because it conflicts with any installable versions previously reported.
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
