### PR TITLE
Bump minimum conda version to 23.3.1

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,7 +2,7 @@
 pip
 # run-time
 boltons>=23.0.0
-conda>=22.11.1
+conda>=23.3.0
 importlib-metadata
 libmamba>=1.4.1
 libmambapy>=1.4.1

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,7 +2,7 @@
 pip
 # run-time
 boltons>=23.0.0
-conda>=23.3.0
+conda>=23.3.1
 importlib-metadata
 libmamba>=1.4.1
 libmambapy>=1.4.1

--- a/news/170-min-conda-version
+++ b/news/170-min-conda-version
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Bumped minimum conda version from 22.11.1 -> 23.3.0 due to change in boltons IndexedSet. (#170)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-  "conda >=22.11.1",
+  "conda >=23.3.0",
   "libmambapy >=1.4.1",
   "importlib-metadata",
   "boltons >=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-  "conda >=23.3.0",
+  "conda >=23.3.1",
   "libmambapy >=1.4.1",
   "importlib-metadata",
   "boltons >=23.0.0",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.7
-    - conda >=23.3.0
+    - conda >=23.3.1
     - libmambapy >=1.4.1
     - importlib-metadata
     - boltons >=23.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.7
-    - conda >=22.11.1
+    - conda >=23.3.0
     - libmambapy >=1.4.1
     - importlib-metadata
     - boltons >=23.0.0


### PR DESCRIPTION
Blocker for release.

### Description

Due to conda boltons vendoring deprication see
https://github.com/conda/conda/pull/12453. Results in issues with `IndexedSet` class changing. Also related to PR #112 

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
