### PR TITLE
Workaround for `defaults::*` specs and `solver.explain_problems()` crashes

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -385,7 +385,7 @@ class LibMambaSolver(Solver):
         for name, spec in out_state.specs.items():
             if name.startswith("__"):
                 continue
-            self._check_spec_compat(spec)
+            spec = self._check_spec_compat(spec)
             spec_str = self._spec_to_str(spec)
             installed = in_state.installed.get(name)
 
@@ -491,7 +491,7 @@ class LibMambaSolver(Solver):
         # --deps-only
         key = ("ERASE | CLEANDEPS", api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
         for name, spec in in_state.requested.items():
-            self._check_spec_compat(spec)
+            spec = self._check_spec_compat(spec)
             tasks[key].append(str(spec))
 
         return dict(tasks)
@@ -504,7 +504,7 @@ class LibMambaSolver(Solver):
         for name, spec in out_state.specs.items():
             if name.startswith("__"):
                 continue
-            self._check_spec_compat(spec)
+            spec = self._check_spec_compat(spec)
             spec = self._fix_version_field_for_conda_build(spec)
             tasks[key].append(spec.conda_build_form())
 
@@ -527,16 +527,19 @@ class LibMambaSolver(Solver):
 
     @staticmethod
     def _str_to_matchspec(spec: Union[str, Sequence[str]]):
-        if isinstance(spec, str):
-            name, version, build = spec.rsplit("-", 2)
-            return MatchSpec(name=name, version=version, build=build)
-        else:
-            kwargs = {"name": spec[0].rstrip(",")}
-            if len(spec) >= 2:
-                kwargs["version"] = spec[1].rstrip(",")
-            if len(spec) == 3:
-                kwargs["build"] = spec[2].rstrip(",")
-            return MatchSpec(**kwargs)
+        try:
+            if isinstance(spec, str):
+                name, version, build = spec.rsplit("-", 2)
+                return MatchSpec(name=name, version=version, build=build)
+            else:
+                kwargs = {"name": spec[0].rstrip(",")}
+                if len(spec) >= 2:
+                    kwargs["version"] = spec[1].rstrip(",")
+                if len(spec) == 3:
+                    kwargs["build"] = spec[2].rstrip(",")
+                return MatchSpec(**kwargs)
+        except Exception as exc:
+            raise ValueError(f"Could not parse spec: {spec}") from exc
 
     @classmethod
     def _parse_problems(cls, problems: str) -> Mapping[str, MatchSpec]:
@@ -550,7 +553,6 @@ class LibMambaSolver(Solver):
         - à la conda-build, e.g. package 1.2.*
         - just names, e.g. package
         """
-
         conflicts = []
         not_found = []
         for line in problems.splitlines():
@@ -568,7 +570,8 @@ class LibMambaSolver(Solver):
                 marker = next((i for (i, w) in enumerate(words) if w == "needed"), None)
                 if marker:
                     conflicts.append(cls._str_to_matchspec(words[-1]))
-                not_found.append(cls._str_to_matchspec(words[4:marker]))
+                start = 3 if marker == 4 else 4
+                not_found.append(cls._str_to_matchspec(words[start:marker]))
 
         return {
             "conflicts": {s.name: s for s in conflicts},
@@ -732,7 +735,7 @@ class LibMambaSolver(Solver):
             kwargs["subdir"] = channel_info.channel.subdir
         return PackageRecord(**kwargs)
 
-    def _check_spec_compat(self, match_spec):
+    def _check_spec_compat(self, match_spec: MatchSpec) -> MatchSpec:
         """
         Make sure we are not silently ingesting MatchSpec fields we are not
         doing anything with!
@@ -752,6 +755,27 @@ class LibMambaSolver(Solver):
                 f"You can only use {supported}, but you tried to use "
                 f"{tuple(unsupported_but_set)}.",
             )
+        if match_spec.get_raw_value("channel") == "defaults":
+            # !!! Temporary !!!
+            # Apply workaround for defaults::pkg-name specs.
+            # We need to replace it with the actual channel name (main, msys2, r)
+            # Instead of searching in the index, we apply a simple heuristic:
+            # - R packages are [_]r-*, mro-*, rpy or rstudio
+            # - Msys2 packages are m2-*, m2w64-*, or msys2-*
+            # - Everything else is in main
+            name = match_spec.name.lower()
+            if (
+                name in ("r", "rpy2", "rstudio")
+                or name.startswith(("r-", "_r-", "mro-")) 
+            ):
+                channel = "pkgs/r"
+            elif name.startswith(("m2-", "m2w64-", "msys2-")):
+                channel = "pkgs/msys2"
+            else:
+                channel = "pkgs/main"
+            match_spec = MatchSpec(match_spec, channel=channel)
+        
+        return match_spec
 
     def _reset(self):
         self.solver = None

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -621,12 +621,12 @@ class LibMambaSolver(Solver):
         legacy_errors = self.solver.problems_to_str()
         if "unsupported request" in legacy_errors:
             # This error makes 'explain_problems()' crash. Anticipate.
-            log.warning("Failed to explain problems. Unsupported request")
+            log.info("Failed to explain problems. Unsupported request")
             return legacy_errors
         try:
             explained_errors = self.solver.explain_problems()
         except Exception as exc:
-            log.warning("Failed to explain problems", exc_info=exc)
+            log.info("Failed to explain problems", exc_info=exc)
             return legacy_errors
         else:
             return f"{legacy_errors}\n{explained_errors}"

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -624,12 +624,12 @@ class LibMambaSolver(Solver):
         legacy_errors = self.solver.problems_to_str()
         if "unsupported request" in legacy_errors:
             # This error makes 'explain_problems()' crash. Anticipate.
-            log.info("Failed to explain problems. Unsupported request")
+            log.info("Failed to explain problems. Unsupported request.")
             return legacy_errors
         try:
             explained_errors = self.solver.explain_problems()
         except Exception as exc:
-            log.info("Failed to explain problems", exc_info=exc)
+            log.warning("Failed to explain problems", exc_info=exc)
             return legacy_errors
         else:
             return f"{legacy_errors}\n{explained_errors}"

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -764,17 +764,14 @@ class LibMambaSolver(Solver):
             # - Msys2 packages are m2-*, m2w64-*, or msys2-*
             # - Everything else is in main
             name = match_spec.name.lower()
-            if (
-                name in ("r", "rpy2", "rstudio")
-                or name.startswith(("r-", "_r-", "mro-")) 
-            ):
+            if name in ("r", "rpy2", "rstudio") or name.startswith(("r-", "_r-", "mro-")):
                 channel = "pkgs/r"
             elif name.startswith(("m2-", "m2w64-", "msys2-")):
                 channel = "pkgs/msys2"
             else:
                 channel = "pkgs/main"
             match_spec = MatchSpec(match_spec, channel=channel)
-        
+
         return match_spec
 
     def _reset(self):

--- a/news/172-defaults-spec-errors
+++ b/news/172-defaults-spec-errors
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Add workaround for `defaults::<pkg_name>` specs. (#173 via #172)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -91,14 +91,15 @@ def test_python_downgrade_reinstalls_noarch_packages():
 
 def test_defaults_specs_work():
     """
-    Reported in https://github.com/conda/conda/issues/11346
+    See https://github.com/conda/conda-libmamba-solver/issues/173
+    
+    `conda install defaults::<pkg_name>` fails with libmamba due to a
+    mapping issue between conda and libmamba.Repo channel names.
+    defaults is secretly (main, r and msys2), and repos are built using those
+    actual channels. A bug in libmamba fails to map this relationship.
 
-    See also test_create::test_noarch_python_package_reinstall_on_pyver_change
-    in conda/conda test suite. Note that we use conda-forge here deliberately;
-    defaults at the time of writing (March 2022) packages pip as a non-noarch
-    build, which means it has a different name across Python versions. conda-forge
-    uses noarch here, so the package is the same across Python versions. Probably
-    why upstream didn't catch this error before.
+    We are testing our workaround (https://github.com/conda/conda-libmamba-solver/issues/173)
+    works for now, but we should probably help fix this in libmamba.
     """
     out, err, rc = run_command(
         "create",
@@ -106,6 +107,9 @@ def test_defaults_specs_work():
         "--dry-run",
         "--json",
         "--solver=libmamba",
+        "--override-channels",
+        "-c",
+        "conda-forge",
         "python=3.10",
         "defaults::libarchive",
         use_exception_handler=True,

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -92,7 +92,7 @@ def test_python_downgrade_reinstalls_noarch_packages():
 def test_defaults_specs_work():
     """
     See https://github.com/conda/conda-libmamba-solver/issues/173
-    
+
     `conda install defaults::<pkg_name>` fails with libmamba due to a
     mapping issue between conda and libmamba.Repo channel names.
     defaults is secretly (main, r and msys2), and repos are built using those


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

```
$ CONDA_SOLVER=libmamba conda create -n dssfdjaime -c defaults python pip defaults::libarchive
Channels:
 - defaults
 - conda-forge
Platform: linux-aarch64
Collecting package metadata (repodata.json): done
Solving environment: / error    libmamba Selected channel specific (or force-reinstall) job, but package is not available from channel. Solve job will fail.
- error    libmamba Selected channel specific (or force-reinstall) job, but package is not available from channel. Solve job will fail.
\ warning  libmamba Problem type not implemented SOLVER_RULE_JOB_UNSUPPORTED
python: /home/conda/feedstock_root/build_artifacts/mamba-split_1679568211070/work/libmamba/src/core/satisfiability_error.cpp:1628: mamba::{anonymous}::TreeExplainer::write_leaf(const mamba::{anonymous}::TreeNode&)::<lambda(const auto:43&)> [with auto:43 = mamba::ProblemsGraph::RootNode]: Assertion `false' failed.
Aborted
```

This crashes Python, no traceback. We are requesting something wrong to libsolv (working on a fix), but then `explained_problems()` crashes trying to elaborate. We anticipate for those errors and avoid the call.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
