### PR TITLE
Require py38+, do not require importlib-metadata

### DIFF
--- a/conda_libmamba_solver/__init__.py
+++ b/conda_libmamba_solver/__init__.py
@@ -5,7 +5,7 @@ try:
     from ._version import version as __version__
 except ImportError:
     try:
-        from importlib_metadata import version
+        from importlib.metadata import version
 
         __version__ = version("conda_libmamba_solver")
         del version

--- a/conda_libmamba_solver/mamba_utils.py
+++ b/conda_libmamba_solver/mamba_utils.py
@@ -8,11 +8,7 @@
 
 import logging
 import os
-
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
+from importlib.metadata import version
 
 import libmambapy as api
 from conda.base.constants import ChannelPriority

--- a/news/174-py38
+++ b/news/174-py38
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Python 3.7 is no longer supported. The minimum version is now 3.8. (#174)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,10 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "conda >=23.3.1",
   "libmambapy >=1.4.1",
-  "importlib-metadata",
   "boltons >=23.0.0",
 ]
 dynamic = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,15 +15,14 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip
     - hatchling
     - hatch-vcs
   run:
-    - python >=3.7
+    - python >=3.8
     - conda >=23.3.1
     - libmambapy >=1.4.1
-    - importlib-metadata
     - boltons >=23.0.0
 
 test:

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -35,7 +35,7 @@ import sys
 from subprocess import PIPE, check_output, run
 
 import pytest
-from importlib_metadata import version
+from importlib.metadata import version
 
 from .channel_testing_utils import (
     create_with_channel,

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -32,10 +32,10 @@ When using `mamba` directly in the CLI, its user agent will start with `mamba/<v
 import json
 import os
 import sys
+from importlib.metadata import version
 from subprocess import PIPE, check_output, run
 
 import pytest
-from importlib.metadata import version
 
 from .channel_testing_utils import (
     create_with_channel,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `conda` ecosystem does not support Python 3.7 anymore, so no need for us either. This also allows us to remove `importlib-metadata` from the dependency list.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
