### PR TITLE
Honor `context.repodata_threads`

### DIFF
--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -73,9 +73,9 @@ and `libmamba.Repo` objects.
 import logging
 import os
 from dataclasses import dataclass
+from functools import partial
 from tempfile import NamedTemporaryFile
 from typing import Iterable, Union
-from functools import partial
 
 import libmambapy as api
 from conda.base.constants import REPODATA_FN

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -75,11 +75,12 @@ import os
 from dataclasses import dataclass
 from tempfile import NamedTemporaryFile
 from typing import Iterable, Union
+from functools import partial
 
 import libmambapy as api
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context
-from conda.common.io import ThreadLimitedThreadPoolExecutor
+from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
 from conda.common.serialize import json_dump, json_load
 from conda.common.url import remove_auth, split_anaconda_token
 from conda.core.subdir_data import SubdirData
@@ -239,7 +240,12 @@ class LibMambaIndexHelper(IndexHelper):
         urls = tuple(dict.fromkeys(urls))  # de-duplicate
 
         # 2. Fetch URLs (if needed)
-        with ThreadLimitedThreadPoolExecutor() as executor:
+        Executor = (
+            DummyExecutor
+            if context.debug or context.repodata_threads == 1
+            else partial(ThreadLimitedThreadPoolExecutor, max_workers=context.repodata_threads)
+        )
+        with Executor() as executor:
             jsons = {url: str(path) for (url, path) in executor.map(self._fetch_channel, urls)}
 
         # 3. Create repos in same order as `urls`

--- a/news/200-repodata-threads
+++ b/news/200-repodata-threads
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Honor `context.repodata_threads`. (#200)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


Run into this while I was researching #197. Apparently consumers are responsible of setting the `Executor` instances correctly (I had assumed it would default to whatever the `context` provided at that time, but that's not true).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
