### PR TITLE
remove `_DownloadOnlySubdirData` and related workarounds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
+          ref: jlap-follow-on
           path: conda
 
       - name: Python ${{ matrix.python-version }}
@@ -99,6 +100,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
+          ref: jlap-follow-on
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -183,6 +185,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
+          ref: jlap-follow-on
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: jlap-follow-on
           path: conda
 
       - name: Python ${{ matrix.python-version }}
@@ -100,7 +99,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: jlap-follow-on
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -185,7 +183,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: jlap-follow-on
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 23.5.x
           path: conda
 
       - name: Python ${{ matrix.python-version }}
@@ -100,7 +99,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 23.5.x
           path: conda
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -185,7 +183,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda
-          ref: 23.5.x
           path: conda
 
       - name: Set temp dirs correctly

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -229,6 +230,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -305,6 +307,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -387,6 +390,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
+          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: 23.5.x
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -230,7 +229,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: 23.5.x
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -307,7 +305,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: 23.5.x
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -390,7 +387,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: 23.5.x
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -230,7 +229,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -307,7 +305,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -390,7 +387,6 @@ jobs:
         with:
           fetch-depth: 0
           repository: conda/conda  # CONDA-LIBMAMBA-SOLVER CHANGE
-          ref: jlap-follow-on
           path: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
 
       # CONDA-LIBMAMBA-SOLVER CHANGE

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -97,7 +97,7 @@ log = logging.getLogger(f"conda.{__name__}")
 
 @dataclass(frozen=True)
 class _ChannelRepoInfo:
-    "A dataclass mapping conda Channels, libmamba Repos and URLs" 
+    "A dataclass mapping conda Channels, libmamba Repos and URLs"
     channel: Channel
     repo: api.Repo
     full_url: str

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -75,7 +75,7 @@ import os
 from dataclasses import dataclass
 from functools import partial
 from tempfile import NamedTemporaryFile
-from typing import Iterable, Union
+from typing import Dict, Iterable, Tuple, Union
 
 import libmambapy as api
 from conda.base.constants import REPODATA_FN
@@ -93,6 +93,15 @@ from .state import IndexHelper
 from .utils import escape_channel_url
 
 log = logging.getLogger(f"conda.{__name__}")
+
+
+@dataclass(frozen=True)
+class _ChannelRepoInfo:
+    "A dataclass mapping conda Channels, libmamba Repos and URLs" 
+    channel: Channel
+    repo: api.Repo
+    full_url: str
+    noauth_url: str
 
 
 class LibMambaIndexHelper(IndexHelper):
@@ -119,7 +128,7 @@ class LibMambaIndexHelper(IndexHelper):
         self._query = api.Query(self._pool)
         self._format = api.QueryFormat.JSON
 
-    def get_info(self, key: str):
+    def get_info(self, key: str) -> _ChannelRepoInfo:
         orig_key = key
         if not key.startswith("file://"):
             # The conda functions (specifically remove_auth) assume the input
@@ -187,7 +196,7 @@ class LibMambaIndexHelper(IndexHelper):
         finally:
             os.unlink(f.name)
 
-    def _fetch_channel(self, url: str) -> api.Repo:
+    def _fetch_channel(self, url: str) -> Tuple[str, os.PathLike]:
         # We could load from subdir_data.iter_records(), but that means
         # re-exporting everything to a temporary JSON path and well,
         # `subdir_data.load()` already did!
@@ -195,28 +204,13 @@ class LibMambaIndexHelper(IndexHelper):
         if not channel.subdir:
             raise ValueError(f"Channel URLs must specify a subdir! Provided: {url}")
 
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            # Workaround some testing issues - TODO: REMOVE
-            # Fix conda.testing.helpers._patch_for_local_exports by removing last line
-            maybe_cached = SubdirData._cache_.get((url, self._repodata_fn))
-            if maybe_cached and maybe_cached._mtime == float("inf"):
-                del SubdirData._cache_[(url, self._repodata_fn)]
-            # /Workaround
+        log.debug("Fetching %s with SubdirData.repo_fetch", channel)
+        subdir_data = SubdirData(channel, repodata_fn=self._repodata_fn)
+        json_path, _ = subdir_data.repo_fetch.fetch_latest_path()
 
-        if hasattr(SubdirData, "repo_fetch"):
-            # New interface
-            log.debug("Fetching %s with SubdirData.repo_fetch", channel)
-            subdir_data = SubdirData(channel, repodata_fn=self._repodata_fn)
-            json_path, _ = subdir_data.repo_fetch.fetch_latest_path()
-        else:
-            # Legacy interface
-            log.debug("Fetching %s with _DownloadOnlySubdirData", channel)
-            subdir_data = _DownloadOnlySubdirData(channel, repodata_fn=self._repodata_fn)
-            subdir_data.load()
-            json_path = subdir_data.cache_path_json
         return url, json_path
 
-    def _load_channels(self):
+    def _load_channels(self) -> Dict[str, _ChannelRepoInfo]:
         # 1. Obtain and deduplicate URLs from channels
         urls = []
         seen_noauth = set()
@@ -264,19 +258,6 @@ class LibMambaIndexHelper(IndexHelper):
         # 4. Configure priorities
         set_channel_priorities(index)
 
-        # 5. Clean up the conda SubdirData cache. We bypassed the post-processing
-        # so now the parent class has a cached instance with no data, which breaks
-        # some tests.
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            log.debug("Cleaning up SubdirData cache")
-            clear_these = []
-            for key, cache in SubdirData._cache_.items():
-                if isinstance(cache, _DownloadOnlySubdirData):
-                    clear_these.append(key)
-
-            for key in clear_these:
-                del SubdirData._cache_[key]
-
         return index
 
     def _load_installed(self, records: Iterable[PackageRecord]) -> api.Repo:
@@ -284,15 +265,15 @@ class LibMambaIndexHelper(IndexHelper):
         repo.set_installed()
         return repo
 
-    def whoneeds(self, query: str, records=True):
+    def whoneeds(self, query: str, records=True) -> Union[Iterable[PackageRecord], dict]:
         result_str = self._query.whoneeds(query, self._format)
         return self._process_query_result(result_str, records=records)
 
-    def depends(self, query: str, records=True):
+    def depends(self, query: str, records=True) -> Union[Iterable[PackageRecord], dict]:
         result_str = self._query.depends(query, self._format)
         return self._process_query_result(result_str, records=records)
 
-    def search(self, query: str, records=True):
+    def search(self, query: str, records=True) -> Union[Iterable[PackageRecord], dict]:
         result_str = self._query.find(query, self._format)
         return self._process_query_result(result_str, records=records)
 
@@ -307,7 +288,11 @@ class LibMambaIndexHelper(IndexHelper):
                 explicit_pool.add(record.name)
         return tuple(explicit_pool)
 
-    def _process_query_result(self, result_str, records=True):
+    def _process_query_result(
+        self,
+        result_str,
+        records=True,
+    ) -> Union[Iterable[PackageRecord], dict]:
         result = json_load(result_str)
         if result.get("result", {}).get("status") != "OK":
             query_type = result.get("query", {}).get("type", "<Unknown>")
@@ -321,35 +306,3 @@ class LibMambaIndexHelper(IndexHelper):
                 pkg_records.append(record)
             return pkg_records
         return result
-
-
-class _DownloadOnlySubdirData(SubdirData):
-    _internal_state_template = {
-        "_package_records": {},
-        "_names_index": {},
-        "_track_features_index": {},
-    }
-
-    def _read_local_repodata(self, *args, **kwargs):
-        return self._internal_state_template
-
-    # Original implementation had a typo in its name which got fixed.
-    # Add alias for backwards compatibility.
-    _read_local_repdata = _read_local_repodata
-
-    def _process_raw_repodata_str(self, *args, **kwargs):
-        return self._internal_state_template
-
-    def _process_raw_repodata(self, *args, **kwargs):
-        return self._internal_state_template
-
-    def _pickle_me(self, *args):
-        return
-
-
-@dataclass(frozen=True)
-class _ChannelRepoInfo:
-    channel: Channel
-    repo: api.Repo
-    full_url: str
-    noauth_url: str

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -197,9 +197,6 @@ class LibMambaIndexHelper(IndexHelper):
             os.unlink(f.name)
 
     def _fetch_channel(self, url: str) -> Tuple[str, os.PathLike]:
-        # We could load from subdir_data.iter_records(), but that means
-        # re-exporting everything to a temporary JSON path and well,
-        # `subdir_data.load()` already did!
         channel = Channel.from_url(url)
         if not channel.subdir:
             raise ValueError(f"Channel URLs must specify a subdir! Provided: {url}")

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -201,6 +201,14 @@ class LibMambaIndexHelper(IndexHelper):
         if not channel.subdir:
             raise ValueError(f"Channel URLs must specify a subdir! Provided: {url}")
 
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            # Workaround some testing issues - TODO: REMOVE
+            # Fix conda.testing.helpers._patch_for_local_exports by removing last line
+            maybe_cached = SubdirData._cache_.get((url, self._repodata_fn))
+            if maybe_cached and maybe_cached._mtime == float("inf"):
+                del SubdirData._cache_[(url, self._repodata_fn)]
+            # /Workaround
+
         log.debug("Fetching %s with SubdirData.repo_fetch", channel)
         subdir_data = SubdirData(channel, repodata_fn=self._repodata_fn)
         json_path, _ = subdir_data.repo_fetch.fetch_latest_path()

--- a/news/210-remove-subdirdata-workarounds
+++ b/news/210-remove-subdirdata-workarounds
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Use the new `RepoInterface` and remove the `SubdirData` subclass workarounds.
+  (#210)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,9 @@ addopts = [
   "--deselect=tests/core/test_solve.py::test_channel_priority_churn_minimized",
   "--deselect=tests/core/test_solve.py::test_priority_1",
   # TODO: Investigate why this fails on Windows now
-  "--deselect=tests/test_create.py::IntegrationTests::test_install_update_deps_only_deps_flags",
+  "--deselect=tests/test_create.py::test_install_update_deps_only_deps_flags",
   # TODO: https://github.com/conda/conda-libmamba-solver/issues/141
-  "--deselect=tests/test_create.py::IntegrationTests::test_conda_pip_interop_conda_editable_package",
+  "--deselect=tests/test_create.py::test_conda_pip_interop_conda_editable_package",
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,15 +80,15 @@ addopts = [
   # Features / nomkl involved
   "--deselect=tests/core/test_solve.py::test_features_solve_1",
   "--deselect=tests/core/test_solve.py::test_prune_1",
-  "--deselect=tests/test_create.py::IntegrationTests::test_remove_features",
+  "--deselect=tests/test_create.py::test_remove_features",
   # Inconsistency analysis not implemented yet
-  "--deselect=tests/test_create.py::IntegrationTests::test_conda_recovery_of_pip_inconsistent_env",
+  "--deselect=tests/test_create.py::test_conda_recovery_of_pip_inconsistent_env",
   # Known bug in mamba; see https://github.com/mamba-org/mamba/issues/1197
-  "--deselect=tests/test_create.py::IntegrationTests::test_offline_with_empty_index_cache",
+  "--deselect=tests/test_create.py::test_offline_with_empty_index_cache",
   # The following are known to fail upstream due to too strict expectations
   # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
-  "--deselect=tests/test_create.py::IntegrationTests::test_neutering_of_historic_specs",
-  "--deselect=tests/test_create.py::IntegrationTests::test_pinned_override_with_explicit_spec",
+  "--deselect=tests/test_create.py::test_neutering_of_historic_specs",
+  "--deselect=tests/test_create.py::test_pinned_override_with_explicit_spec",
   "--deselect=tests/core/test_solve.py::test_pinned_1",
   "--deselect=tests/core/test_solve.py::test_freeze_deps_1",
   "--deselect=tests/core/test_solve.py::test_cuda_fail_1",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We only left those parts around in case the `repodata.fetch` stuff was not too stable, but we require a recent `conda` anyway due to some API breakages, so I think we can just remove those now, as well as the associated workarounds.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
