### PR TITLE
Revisit some issues with scheduled runs and upstream tests collection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,7 @@ jobs:
             --file ../conda-libmamba-solver/tests/requirements.txt \
             python=${{ matrix.python-version }}
           conda update openssl ca-certificates certifi
+          python -m pip install ../conda-libmamba-solver/dev/collect_upstream_conda_tests -vv
           conda info
           python -c "from importlib.metadata import version; print('libmambapy', version('libmambapy'))"
 
@@ -242,6 +243,8 @@ jobs:
           if errorlevel 1 exit 1
           :: initialize conda dev
           call .\dev\windows\setup.bat
+          if errorlevel 1 exit 1
+          python -m pip install ..\conda-libmamba-solver\dev\collect_upstream_conda_tests -vv
           if errorlevel 1 exit 1
           call .\dev-init.bat
           if errorlevel 1 exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&
                    source /opt/conda-src/dev/linux/bashrc.sh &&
                    /opt/conda/bin/python -m pytest /opt/conda-libmamba-solver-src -vv -m 'not slow'"
-      
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v3
@@ -267,7 +267,7 @@ jobs:
           if errorlevel 1 exit 1
           python -m pytest "%GITHUB_WORKSPACE%\conda-libmamba-solver" -vv -m "not slow" --timeout=600
           if errorlevel 1 exit 1
-      
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,7 @@ jobs:
                         --file /opt/conda-libmamba-solver-src/dev/requirements.txt \
                         --file /opt/conda-libmamba-solver-src/tests/requirements.txt &&
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&
+                   /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src/dev/collect_upstream_conda_tests/ -vvv &&
                    source /opt/conda-src/dev/linux/bashrc.sh &&
                    /opt/conda/bin/python -m pytest /opt/conda-libmamba-solver-src -vv -m 'not slow'"
 
@@ -244,8 +245,6 @@ jobs:
           :: initialize conda dev
           call .\dev\windows\setup.bat
           if errorlevel 1 exit 1
-          python -m pip install ..\conda-libmamba-solver\dev\collect_upstream_conda_tests -vv
-          if errorlevel 1 exit 1
           call .\dev-init.bat
           if errorlevel 1 exit 1
           python -c "from importlib.metadata import version; print('libmambapy', version('libmambapy'))"
@@ -258,6 +257,8 @@ jobs:
         working-directory: conda
         run: |
           call .\dev-init.bat
+          if errorlevel 1 exit 1
+          python -m pip install -vv "%GITHUB_WORKSPACE%\conda-libmamba-solver\dev\collect_upstream_conda_tests"
           if errorlevel 1 exit 1
           python -m pip install --no-deps -vv "%GITHUB_WORKSPACE%\conda-libmamba-solver"
           if errorlevel 1 exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,18 @@ jobs:
                    /opt/conda/bin/python -m pip install /opt/conda-libmamba-solver-src --no-deps -vvv &&
                    source /opt/conda-src/dev/linux/bashrc.sh &&
                    /opt/conda/bin/python -m pytest /opt/conda-libmamba-solver-src -vv -m 'not slow'"
+      
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
+          # when locally dowloading and comparing results of different workflow runs.
+          name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-cls
+          path: |
+            conda/.coverage
+            conda/test-report.xml
+          retention-days: 1
 
   macos:
     name: MacOS, Python ${{ matrix.python-version }}, ${{ matrix.default-channel }}
@@ -165,6 +177,18 @@ jobs:
           eval "$(sudo ${CONDA_PREFIX}/bin/python -m conda init bash --dev)"
           python -m pytest ${GITHUB_WORKSPACE}/conda-libmamba-solver -vv -m "not slow"
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
+          # when locally dowloading and comparing results of different workflow runs.
+          name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-cls
+          path: |
+            conda/.coverage
+            conda/test-report.xml
+          retention-days: 1
+
   windows:
     name: Windows, Python ${{ matrix.python-version }}, ${{ matrix.default-channel }}
     runs-on: windows-latest
@@ -243,11 +267,25 @@ jobs:
           if errorlevel 1 exit 1
           python -m pytest "%GITHUB_WORKSPACE%\conda-libmamba-solver" -vv -m "not slow" --timeout=600
           if errorlevel 1 exit 1
+      
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
+          # when locally dowloading and comparing results of different workflow runs.
+          name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-cls
+          path: |
+            conda/.coverage
+            conda/test-report.xml
+          retention-days: 1
 
-  analyze:
-    name: Analyze test results
+  # aggregate and upload
+  aggregate:
+    # only aggregate test suite if there are code changes
     needs: [windows, linux, macos]
     if: always()
+
     runs-on: ubuntu-latest
     steps:
       - name: Download test results
@@ -258,22 +296,36 @@ jobs:
         # of all matrix runs for further analysis.
         uses: actions/upload-artifact@v3
         with:
-          name: test-results-${{ github.sha }}-all
+          name: test-results-${{ github.sha }}-cls-all
           path: test-results-${{ github.sha }}-*
-          retention-days: 90  # default: 90
+          retention-days: 30  # default: 90
 
       - name: Test Summary
         uses: test-summary/action@v2
         with:
           paths: ./test-results-${{ github.sha }}-**/test-report*.xml
 
+  # required check
+  analyze:
+    name: Analyze results
+    needs: [windows, linux, macos, aggregate]
+    if: always()
+
+    runs-on: ubuntu-latest
+    steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        id: alls-green # CONDA-LIBMAMBA-SOLVER CHANGE
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
+          allowed-skips: ${{ toJSON(needs) }}
           jobs: ${{ toJSON(needs) }}
 
+      - name: Checkout our source
+        uses: actions/checkout@v3
+        if: github.event_name == 'schedule' && steps.alls-green.outputs.failure
+
       - name: Report failures
-        if: github.event_name == 'schedule' && failure()
+        if: github.event_name == 'schedule' && steps.alls-green.outputs.failure
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CONDA_LIBMAMBA_SOLVER_ISSUES }}

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -159,15 +159,13 @@ jobs:
           call .\dev-init.bat
           if errorlevel 1 exit 1
           :: /original logic
+          :: Install test collection plugin
+          python -m pip install -vv "%GITHUB_WORKSPACE%\conda-libmamba-solver\dev\collect_upstream_conda_tests"
+          if errorlevel 1 exit 1
           :: Install conda-libmamba-solver
           python -m pip install --no-deps -vv "%GITHUB_WORKSPACE%\conda-libmamba-solver"
           if errorlevel 1 exit 1
           python -c "from importlib.metadata import version; print('libmambapy', version('libmambapy'))"
-          if errorlevel 1 exit 1
-          :: override pytest settings
-          copy "%GITHUB_WORKSPACE%\conda-libmamba-solver\pyproject.toml" .\pyproject.toml
-          if errorlevel 1 exit 1
-          del .\setup.cfg
           if errorlevel 1 exit 1
           call conda info -a
           if errorlevel 1 exit 1
@@ -239,11 +237,6 @@ jobs:
         with:
           fetch-depth: 0
           path: conda-libmamba-solver
-      - name: Override pytest settings
-        run: |
-          # override pytest settings
-          cp conda-libmamba-solver/pyproject.toml conda/pyproject.toml
-          rm conda/setup.cfg
       # /CONDA-LIBMAMBA-SOLVER CHANGE
 
       - name: Python ${{ matrix.python-version }} on ${{ matrix.default-channel }}, ${{ matrix.test-type }} tests, group ${{ matrix.test-group }}
@@ -453,11 +446,9 @@ jobs:
           ./dev/macos/setup.sh
           # /original setup
           python -c "from importlib.metadata import version; print('libmambapy', version('libmambapy'))"
+          python -m pip install ../conda-libmamba-solver/dev/collect_upstream_conda_tests -vv
           python -m pip install ../conda-libmamba-solver -vv --no-deps
           conda info -a
-          # override pytest settings
-          cp ../conda-libmamba-solver/pyproject.toml ./pyproject.toml
-          rm ./setup.cfg
           # /CONDA-LIBMAMBA-SOLVER CHANGE
 
       - name: Python ${{ matrix.python-version }} on ${{ matrix.default-channel }}, ${{ matrix.test-type }} tests, group ${{ matrix.test-group }}

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -44,7 +44,8 @@ jobs:
       - uses: actions/checkout@v3
         # dorny/paths-filter needs git clone for push events
         # https://github.com/marketplace/actions/paths-changes-filter#supported-workflows
-        if: github.event_name == 'push'
+        # CONDA-LIBMAMBA-SOLVER CHANGE
+        if: github.event_name != 'pull_request'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
         id: filter
         with:
@@ -63,7 +64,7 @@ jobs:
   windows:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
 
     runs-on: windows-2019
     strategy:
@@ -192,17 +193,18 @@ jobs:
           # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
           # when locally dowloading and comparing results of different workflow runs.
           name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-${{ matrix.conda-subdir }}-${{ matrix.test-type }}-${{ matrix.test-group }}
+          # CONDA-LIBMAMBA-SOLVER CHANGE: need to prepend conda/ to the paths
           path: |
-            .coverage
-            .test_durations_${OS}
-            test-report.xml
+            conda/.coverage
+            conda/.test_durations_${OS}
+            conda/test-report.xml
           retention-days: 1
 
   # linux test suite
   linux:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
 
     runs-on: ubuntu-latest
     strategy:
@@ -272,10 +274,11 @@ jobs:
           # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
           # when locally dowloading and comparing results of different workflow runs.
           name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-${{ matrix.test-type }}-${{ matrix.test-group }}
+          # CONDA-LIBMAMBA-SOLVER CHANGE: need to prepend conda/ to the paths
           path: |
-            .coverage
-            .test_durations_${OS}
-            test-report.xml
+            conda/.coverage
+            conda/.test_durations_${OS}
+            conda/test-report.xml
           retention-days: 1
 
   # linux-qemu test suite
@@ -343,16 +346,17 @@ jobs:
           # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
           # when locally dowloading and comparing results of different workflow runs.
           name: test-results-${{ github.sha }}-linux-${{ matrix.platform }}-qemu-${{ matrix.default-channel }}-${{ matrix.python-version }}
+          # CONDA-LIBMAMBA-SOLVER CHANGE: need to prepend conda/ to the paths
           path: |
-            .coverage
-            test-report.xml
+            conda/.coverage
+            conda/test-report.xml
           retention-days: 1
 
   # macos test suite
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
 
     runs-on: macos-latest
     strategy:
@@ -476,17 +480,18 @@ jobs:
           # name has to be unique, to not overwrite uploads of other matrix runs. sha1 is optional and only to differentiate
           # when locally dowloading and comparing results of different workflow runs.
           name: test-results-${{ github.sha }}-${{ runner.os }}-${{ matrix.default-channel }}-${{ matrix.python-version }}-${{ matrix.test-type }}-${{ matrix.test-group }}
+          # CONDA-LIBMAMBA-SOLVER CHANGE: need to prepend conda/ to the paths
           path: |
-            .coverage
-            .test_durations_${OS}
-            test-report.xml
+            conda/.coverage
+            conda/.test_durations_${OS}
+            conda/test-report.xml
           retention-days: 1
 
   # aggregate and upload
   aggregate:
     # only aggregate test suite if there are code changes
     needs: [changes, windows, linux, linux-qemu, macos]
-    if: needs.changes.outputs.code == 'true' && always()
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
 
     runs-on: ubuntu-latest
     steps:
@@ -523,13 +528,17 @@ jobs:
           jobs: ${{ toJSON(needs) }}
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
+      - name: Checkout our source
+        uses: actions/checkout@v3
+        if: github.event_name == 'schedule' && steps.alls-green.outputs.failure
+
       - name: Report failures
         if: github.event_name == 'schedule' && steps.alls-green.outputs.failure
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CONDA_LIBMAMBA_SOLVER_ISSUES }}
           RUN_ID: ${{ github.run_id }}
-          TITLE: "Scheduled tests failed"
+          TITLE: "Scheduled upstream tests failed"
         with:
           filename: .github/TEST_FAILURE_REPORT_TEMPLATE.md
           update_existing: true
@@ -542,10 +551,12 @@ jobs:
     # only build canary build if
     # - prior steps succeeded,
     # - this is the main repo, and
+    # - event triggered by push, and  # CONDA-LIBMAMBA-SOLVER CHANGE
     # - we are on the main (or feature) branch
     if: >-
       success()
       && !github.event.repository.fork
+      && github.event_name == 'push'
       && (
         github.ref_name == 'main'
         || startsWith(github.ref_name, 'feature/')

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -123,12 +123,8 @@ def pytest_collection_modifyitems(session, config, items):
             continue
         if version(
             "libmambapy"
-        ) >= "1.4.2" and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(
-            path_key, []
-        ):
-            item.add_marker(
-                pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186")
-            )
+        ) >= "1.4.2" and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(path_key, []):
+            item.add_marker(pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186"))
         selected.append(item)
     items[:] = selected
     config.hook.pytest_deselected(items=deselected)

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -1,0 +1,102 @@
+"""
+pytest plugin to modify which upstream (conda/conda) tests are run by pytest.
+"""
+from importlib.metadata import version
+
+import pytest
+
+
+_deselected_upstream_tests = [
+    ### Deselect tests from conda/conda we cannot pass due to different reasons
+    ### These used to be skipped or xfail'd upstream, but we are trying to
+    ### keep it clean from this project's specifics
+    # This test checks for plugin errors and assumes none are present, but
+    # conda-libmamba-solver counts as one so we need to skip it.
+    "tests/plugins/test_manager.py::test_load_entrypoints_importerror",
+    # Conflict report / analysis is done differently with libmamba.
+    "tests/cli/test_cli_install.py::test_find_conflicts_called_once",
+    # SolverStateContainer needed
+    "tests/core/test_solve.py::test_solve_2",
+    "tests/core/test_solve.py::test_virtual_package_solver",
+    "tests/core/test_solve.py::test_broken_install",
+    # Features / nomkl involved
+    "tests/core/test_solve.py::test_features_solve_1",
+    "tests/core/test_solve.py::test_prune_1",
+    "tests/test_create.py::test_remove_features",
+    # Inconsistency analysis not implemented yet
+    "tests/test_create.py::test_conda_recovery_of_pip_inconsistent_env",
+    # Known bug in mamba; see https://github.com/mamba-org/mamba/issues/1197
+    "tests/test_create.py::test_offline_with_empty_index_cache",
+    # The following are known to fail upstream due to too strict expectations
+    # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
+    "tests/test_create.py::test_neutering_of_historic_specs",
+    "tests/test_create.py::test_pinned_override_with_explicit_spec",
+    "tests/core/test_solve.py::test_pinned_1",
+    "tests/core/test_solve.py::test_freeze_deps_1",
+    "tests/core/test_solve.py::test_cuda_fail_1",
+    "tests/core/test_solve.py::test_cuda_fail_2",
+    "tests/core/test_solve.py::test_update_all_1",
+    "tests/core/test_solve.py::test_conda_downgrade",
+    "tests/core/test_solve.py::test_python2_update",
+    "tests/core/test_solve.py::test_fast_update_with_update_modifier_not_set",
+    "tests/core/test_solve.py::test_downgrade_python_prevented_with_sane_message",
+    # These use libmamba-incompatible MatchSpecs (name[build_number=1] syntax)
+    "tests/models/test_prefix_graph.py::test_deep_cyclical_dependency",
+    # See https://github.com/conda/conda-libmamba-solver/pull/133#issuecomment-1448607110
+    # These failed after enabling the whole unit test suite for `conda/conda`.
+    # Errors are not critical but would require some further assessment in case fixes are obvious.
+    "tests/cli/test_main_notices.py::test_notices_appear_once_when_running_decorated_commands",
+    "tests/cli/test_main_notices.py::test_notices_does_not_interrupt_command_on_failure",
+    "tests/conda_env/installers/test_pip.py::PipInstallerTest::test_stops_on_exception",
+    "tests/conda_env/installers/test_pip.py::PipInstallerTest::test_straight_install",
+    "tests/conda_env/specs/test_base.py::DetectTestCase::test_build_msg",
+    "tests/conda_env/specs/test_base.py::DetectTestCase::test_dispatches_to_registered_specs",
+    "tests/conda_env/specs/test_base.py::DetectTestCase::test_has_build_msg_function",
+    "tests/conda_env/specs/test_base.py::DetectTestCase::test_passes_kwargs_to_all_specs",
+    "tests/conda_env/specs/test_base.py::DetectTestCase::test_raises_exception_if_no_detection",
+    # TODO: Fix upstream; they seem to assume no other solvers will be active via env var
+    "tests/plugins/test_solvers.py::test_get_solver_backend",
+    "tests/plugins/test_solvers.py::test_get_solver_backend_multiple",
+    # TODO: Investigate these, since they are solver related-ish
+    "tests/conda_env/specs/test_requirements.py::TestRequiremets::test_environment",
+    "tests/models/test_prefix_graph.py::test_windows_sort_orders_1",
+    # TODO: These ones need further investigation
+    "tests/core/test_solve.py::test_channel_priority_churn_minimized",
+    "tests/core/test_solve.py::test_priority_1",
+    # TODO: Investigate why this fails on Windows now
+    "tests/test_create.py::test_install_update_deps_only_deps_flags",
+    # TODO: https://github.com/conda/conda-libmamba-solver/issues/141
+    "tests/test_create.py::test_conda_pip_interop_conda_editable_package",
+]
+
+_broken_by_libmamba_1_4_2 = [
+    # conda/tests
+    "tests/core/test_solve.py::test_force_remove_1",
+    "tests/core/test_solve.py::test_aggressive_update_packages",
+    "tests/core/test_solve.py::test_update_deps_2",
+    "tests/test_create.py::test_conda_pip_interop_dependency_satisfied_by_pip", # Linux-only
+    "tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda", # Linux-only
+    "tests/test_create.py::test_install_tarball_from_local_channel", # Linux-only
+    # conda-libmamba-solver/tests
+    "tests/test_modified_upstream.py::test_pinned_1",
+]
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """
+    We use this hook to modify which upstream tests (from the conda/conda repo)
+    are run by pytest.
+
+    This hook should not return anything but, instead, modify in place.
+    """
+    selected = []
+    deselected = []
+    for item in items:
+        if item.nodeid in _deselected_upstream_tests:
+            deselected.append(item)
+            continue
+        if version("libmambapy") >= "1.4.2" and item.nodeid in _broken_by_libmamba_1_4_2:
+            item.add_marker(pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186"))
+        selected.append(item)
+    items[:] = selected
+    config.hook.pytest_deselected(items=deselected)

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -5,7 +5,6 @@
 pytest plugin to modify which upstream (conda/conda) tests are run by pytest.
 """
 from importlib.metadata import version
-from pathlib import Path
 
 import pytest
 
@@ -116,14 +115,14 @@ def pytest_collection_modifyitems(session, config, items):
     selected = []
     deselected = []
     for item in items:
-        shortpath = Path(*item.path.parts[item.path.parts.index("tests"):])
+        path_key = "/".join(item.path.parts[item.path.parts.index("tests"):])
         item_name_no_brackets = item.name.split("[")[0]
-        if item_name_no_brackets in _deselected_upstream_tests.get(str(shortpath), []):
+        if item_name_no_brackets in _deselected_upstream_tests.get(path_key, []):
             deselected.append(item)
             continue
         if (
             version("libmambapy") >= "1.4.2"
-            and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(str(shortpath), [])
+            and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(path_key, [])
         ):
             item.add_marker(
                 pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186")

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -5,83 +5,105 @@
 pytest plugin to modify which upstream (conda/conda) tests are run by pytest.
 """
 from importlib.metadata import version
+from pathlib import Path
 
 import pytest
 
 # Deselect tests from conda/conda we cannot pass due to different reasons
 # These used to be skipped or xfail'd upstream, but we are trying to
 # keep it clean from this project's specifics
-_deselected_upstream_tests = [
+_deselected_upstream_tests = {
     # This test checks for plugin errors and assumes none are present, but
     # conda-libmamba-solver counts as one so we need to skip it.
-    "tests/plugins/test_manager.py::test_load_entrypoints_importerror",
+    "tests/plugins/test_manager.py": ["test_load_entrypoints_importerror"],
     # Conflict report / analysis is done differently with libmamba.
-    "tests/cli/test_cli_install.py::test_find_conflicts_called_once",
-    # SolverStateContainer needed
-    "tests/core/test_solve.py::test_solve_2",
-    "tests/core/test_solve.py::test_virtual_package_solver",
-    "tests/core/test_solve.py::test_broken_install",
-    # Features / nomkl involved
-    "tests/core/test_solve.py::test_features_solve_1",
-    "tests/core/test_solve.py::test_prune_1",
-    "tests/test_create.py::test_remove_features",
-    # Inconsistency analysis not implemented yet
-    "tests/test_create.py::test_conda_recovery_of_pip_inconsistent_env",
-    # Known bug in mamba; see https://github.com/mamba-org/mamba/issues/1197
-    "tests/test_create.py::test_offline_with_empty_index_cache",
-    # The following are known to fail upstream due to too strict expectations
-    # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
-    "tests/test_create.py::test_neutering_of_historic_specs",
-    "tests/test_create.py::test_pinned_override_with_explicit_spec",
-    "tests/core/test_solve.py::test_pinned_1",
-    "tests/core/test_solve.py::test_freeze_deps_1",
-    "tests/core/test_solve.py::test_cuda_fail_1",
-    "tests/core/test_solve.py::test_cuda_fail_2",
-    "tests/core/test_solve.py::test_update_all_1",
-    "tests/core/test_solve.py::test_conda_downgrade",
-    "tests/core/test_solve.py::test_python2_update",
-    "tests/core/test_solve.py::test_fast_update_with_update_modifier_not_set",
-    "tests/core/test_solve.py::test_downgrade_python_prevented_with_sane_message",
+    "tests/cli/test_cli_install.py": ["test_find_conflicts_called_once"],
+    "tests/core/test_solve.py": [
+        # SolverStateContainer needed
+        "test_solve_2",
+        "test_virtual_package_solver",
+        "test_broken_install",
+        # Features / nomkl involved
+        "test_features_solve_1",
+        "test_prune_1",
+        # TODO: These ones need further investigation
+        "test_channel_priority_churn_minimized",
+        "test_priority_1",
+        # The following are known to fail upstream due to too strict expectations
+        # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
+        "test_pinned_1",
+        "test_freeze_deps_1",
+        "test_cuda_fail_1",
+        "test_cuda_fail_2",
+        "test_update_all_1",
+        "test_conda_downgrade",
+        "test_python2_update",
+        "test_fast_update_with_update_modifier_not_set",
+        "test_downgrade_python_prevented_with_sane_message",
+    ],
+    "tests/test_create.py": [
+        "test_remove_features",
+        # Inconsistency analysis not implemented yet
+        "test_conda_recovery_of_pip_inconsistent_env",
+        # Known bug in mamba; see https://github.com/mamba-org/mamba/issues/1197
+        "test_offline_with_empty_index_cache",
+        "test_neutering_of_historic_specs",
+        "test_pinned_override_with_explicit_spec",
+        # TODO: Investigate why this fails on Windows now
+        "test_install_update_deps_only_deps_flags",
+        # TODO: https://github.com/conda/conda-libmamba-solver/issues/141
+        "test_conda_pip_interop_conda_editable_package",
+    ],
     # These use libmamba-incompatible MatchSpecs (name[build_number=1] syntax)
-    "tests/models/test_prefix_graph.py::test_deep_cyclical_dependency",
+    "tests/models/test_prefix_graph.py": [
+        "test_deep_cyclical_dependency",
+        # TODO: Investigate this, since they are solver related-ish
+        "test_windows_sort_orders_1",
+    ],
     # See https://github.com/conda/conda-libmamba-solver/pull/133#issuecomment-1448607110
     # These failed after enabling the whole unit test suite for `conda/conda`.
     # Errors are not critical but would require some further assessment in case fixes are obvious.
-    "tests/cli/test_main_notices.py::test_notices_appear_once_when_running_decorated_commands",
-    "tests/cli/test_main_notices.py::test_notices_does_not_interrupt_command_on_failure",
-    "tests/conda_env/installers/test_pip.py::PipInstallerTest::test_stops_on_exception",
-    "tests/conda_env/installers/test_pip.py::PipInstallerTest::test_straight_install",
-    "tests/conda_env/specs/test_base.py::DetectTestCase::test_build_msg",
-    "tests/conda_env/specs/test_base.py::DetectTestCase::test_dispatches_to_registered_specs",
-    "tests/conda_env/specs/test_base.py::DetectTestCase::test_has_build_msg_function",
-    "tests/conda_env/specs/test_base.py::DetectTestCase::test_passes_kwargs_to_all_specs",
-    "tests/conda_env/specs/test_base.py::DetectTestCase::test_raises_exception_if_no_detection",
+    "tests/cli/test_main_notices.py": [
+        "test_notices_appear_once_when_running_decorated_commands",
+        "test_notices_does_not_interrupt_command_on_failure",
+    ],
+    "tests/conda_env/installers/test_pip.py": [
+        "PipInstallerTest::test_stops_on_exception",
+        "PipInstallerTest::test_straight_install",
+    ],
+    "tests/conda_env/specs/test_base.py": [
+        "DetectTestCase::test_build_msg",
+        "DetectTestCase::test_dispatches_to_registered_specs",
+        "DetectTestCase::test_has_build_msg_function",
+        "DetectTestCase::test_passes_kwargs_to_all_specs",
+        "DetectTestCase::test_raises_exception_if_no_detection",
+    ],
     # TODO: Fix upstream; they seem to assume no other solvers will be active via env var
-    "tests/plugins/test_solvers.py::test_get_solver_backend",
-    "tests/plugins/test_solvers.py::test_get_solver_backend_multiple",
+    "tests/plugins/test_solvers.py": [
+        "test_get_solver_backend",
+        "test_get_solver_backend_multiple",
+    ],
     # TODO: Investigate these, since they are solver related-ish
-    "tests/conda_env/specs/test_requirements.py::TestRequiremets::test_environment",
-    "tests/models/test_prefix_graph.py::test_windows_sort_orders_1",
-    # TODO: These ones need further investigation
-    "tests/core/test_solve.py::test_channel_priority_churn_minimized",
-    "tests/core/test_solve.py::test_priority_1",
-    # TODO: Investigate why this fails on Windows now
-    "tests/test_create.py::test_install_update_deps_only_deps_flags",
-    # TODO: https://github.com/conda/conda-libmamba-solver/issues/141
-    "tests/test_create.py::test_conda_pip_interop_conda_editable_package",
-]
+    "tests/conda_env/specs/test_requirements.py": ["TestRequiremets::test_environment"],
+}
 
-_broken_by_libmamba_1_4_2 = [
+_broken_by_libmamba_1_4_2 = {
     # conda/tests
-    "tests/core/test_solve.py::test_force_remove_1",
-    "tests/core/test_solve.py::test_aggressive_update_packages",
-    "tests/core/test_solve.py::test_update_deps_2",
-    "tests/test_create.py::test_conda_pip_interop_dependency_satisfied_by_pip",  # Linux-only
-    "tests/test_create.py::test_conda_pip_interop_pip_clobbers_conda",  # Linux-only
-    "tests/test_create.py::test_install_tarball_from_local_channel",  # Linux-only
+    "tests/core/test_solve.py": [
+        "test_force_remove_1",
+        "test_aggressive_update_packages",
+        "test_update_deps_2",
+    ],
+    "tests/test_create.py": [
+        "test_conda_pip_interop_dependency_satisfied_by_pip",  # Linux-only
+        "test_conda_pip_interop_pip_clobbers_conda",  # Linux-only
+        "test_install_tarball_from_local_channel",  # Linux-only
+    ],
     # conda-libmamba-solver/tests
-    "tests/test_modified_upstream.py::test_pinned_1",
-]
+    "tests/test_modified_upstream.py": [
+        "test_pinned_1",
+    ],
+}
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -94,12 +116,14 @@ def pytest_collection_modifyitems(session, config, items):
     selected = []
     deselected = []
     for item in items:
-        if item.nodeid in _deselected_upstream_tests:
+        shortpath = Path(*item.path.parts[item.path.parts.index("tests"):])
+        item_name_no_brackets = item.name.split("[")[0]
+        if item_name_no_brackets in _deselected_upstream_tests.get(str(shortpath), []):
             deselected.append(item)
             continue
         if (
             version("libmambapy") >= "1.4.2"
-            and item.nodeid in _broken_by_libmamba_1_4_2
+            and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(str(shortpath), [])
         ):
             item.add_marker(
                 pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186")

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -115,14 +115,15 @@ def pytest_collection_modifyitems(session, config, items):
     selected = []
     deselected = []
     for item in items:
-        path_key = "/".join(item.path.parts[item.path.parts.index("tests"):])
+        path_key = "/".join(item.path.parts[item.path.parts.index("tests") :])
         item_name_no_brackets = item.name.split("[")[0]
         if item_name_no_brackets in _deselected_upstream_tests.get(path_key, []):
             deselected.append(item)
             continue
-        if (
-            version("libmambapy") >= "1.4.2"
-            and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(path_key, [])
+        if version(
+            "libmambapy"
+        ) >= "1.4.2" and item_name_no_brackets in _broken_by_libmamba_1_4_2.get(
+            path_key, []
         ):
             item.add_marker(
                 pytest.mark.xfail(reason="Broken by libmamba 1.4.2; see #186")

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -94,6 +94,7 @@ _broken_by_libmamba_1_4_2 = {
         "test_update_deps_2",
     ],
     "tests/test_create.py": [
+        "test_list_with_pip_wheel",
         "test_conda_pip_interop_dependency_satisfied_by_pip",  # Linux-only
         "test_conda_pip_interop_pip_clobbers_conda",  # Linux-only
         "test_install_tarball_from_local_channel",  # Linux-only

--- a/dev/collect_upstream_conda_tests/pyproject.toml
+++ b/dev/collect_upstream_conda_tests/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "collect-upstream-conda-tests"
+version = "0.0.1"
+description = "A pytest plugin to filter which upstream tests are run"
+authors = [
+  {name = "Anaconda, Inc.", email = "conda@continuum.io"}
+]
+license = {file = "../../LICENSE"}
+classifiers = [
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy"
+]
+requires-python = ">=3.8"
+dependencies = [
+  "pytest",
+]
+
+[project.urls]
+homepage = "https://github.com/conda/conda-libmamba-solver"
+
+[project.entry-points.pytest11]
+collect-upstream-conda-tests = "collect_upstream_conda_tests"

--- a/dev/linux/bashrc.sh
+++ b/dev/linux/bashrc.sh
@@ -44,7 +44,7 @@ if [ -d "/opt/mamba-src" ]; then
 fi
 
 cd /opt/conda-libmamba-solver-src
-sudo /opt/conda/bin/python -m pip install dev/collect_upstream_conda_tests/
+sudo /opt/conda/bin/python -m pip install ./dev/collect_upstream_conda_tests/
 sudo /opt/conda/bin/python -m pip install -e . --no-deps
 
 cd /opt/conda-src

--- a/dev/linux/bashrc.sh
+++ b/dev/linux/bashrc.sh
@@ -44,6 +44,7 @@ if [ -d "/opt/mamba-src" ]; then
 fi
 
 cd /opt/conda-libmamba-solver-src
+sudo /opt/conda/bin/python -m pip install dev/collect_upstream_conda_tests/
 sudo /opt/conda/bin/python -m pip install -e . --no-deps
 
 cd /opt/conda-src

--- a/dev/linux/upstream_integration.sh
+++ b/dev/linux/upstream_integration.sh
@@ -19,6 +19,7 @@ sudo su root -c "/opt/conda/bin/conda install -yq conda-build"
 sudo /opt/conda/bin/conda install --quiet -y --solver=classic \
     --file "${CONDA_SRC}/tests/requirements.txt" \
     --file "${CONDA_LIBMAMBA_SOLVER_SRC}/dev/requirements.txt"
+sudo /opt/conda/bin/python -m pip install "$CONDA_LIBMAMBA_SOLVER_SRC/dev/collect_upstream_conda_tests/"
 sudo /opt/conda/bin/python -m pip install "$CONDA_LIBMAMBA_SOLVER_SRC" --no-deps -vvv
 # /CONDA LIBMAMBA SOLVER CHANGES
 eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"

--- a/dev/linux/upstream_unit.sh
+++ b/dev/linux/upstream_unit.sh
@@ -19,6 +19,7 @@ eval "$(sudo /opt/conda/bin/python -m conda init --dev bash)"
 sudo /opt/conda/bin/conda install --quiet -y --solver=classic \
     --file "${CONDA_SRC}/tests/requirements.txt" \
     --file "${CONDA_LIBMAMBA_SOLVER_SRC}/dev/requirements.txt"
+sudo /opt/conda/bin/python -m pip install "$CONDA_LIBMAMBA_SOLVER_SRC/dev/collect_upstream_conda_tests/"
 sudo /opt/conda/bin/python -m pip install "$CONDA_LIBMAMBA_SOLVER_SRC" --no-deps -vvv
 # /CONDA LIBMAMBA SOLVER CHANGES
 

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -3,7 +3,7 @@ pip
 # run-time
 boltons>=23.0.0
 conda>=23.3.1
-libmamba>=1.4.1,!=1.4.2
-libmambapy>=1.4.1,!=1.4.2
+libmamba<=1.4.1 # see https://github.com/conda/conda-libmamba-solver/issues/186
+libmambapy<=1.4.1 # see https://github.com/conda/conda-libmamba-solver/issues/186
 # be explicit about sqlite because sometimes it's removed from the env :shrug:
 sqlite

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -3,7 +3,7 @@ pip
 # run-time
 boltons>=23.0.0
 conda>=23.3.1
-libmamba<=1.4.1 # see https://github.com/conda/conda-libmamba-solver/issues/186
-libmambapy<=1.4.1 # see https://github.com/conda/conda-libmamba-solver/issues/186
+libmamba>=1.4.1
+libmambapy>=1.4.1
 # be explicit about sqlite because sometimes it's removed from the env :shrug:
 sqlite

--- a/docs/dev/implementation.md
+++ b/docs/dev/implementation.md
@@ -23,8 +23,6 @@ Some peculiarities:
 * `hatchling` is the chosen backend for the packaging.
 * The `version` is calculated from the `git` info with `hatchling-vcs`.
 * `black` uses a line length of 99 characters.
-* Pytest configurations are extensive but are only necessary when dealing with upstream testing.
-  Check "Development workflows" for details.
 
 ## `conda_libmamba_solver` package
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -77,6 +77,13 @@ $ cd $REPO_LOCATION
 $ python -m pip install --no-deps -e .
 ```
 
+5. Install the test collection plugins (only for upstream tests in `conda/conda`):
+
+```bash
+$ cd $REPO_LOCATION
+$ python -m pip install dev/collect_upstream_conda_tests/
+```
+
 For testing out the `libmamba` solve you can set it several ways:
  - environment variable `CONDA_SOLVER=libmamba`
  - pass a flag `--solver=libmamba`

--- a/docs/dev/workflows.md
+++ b/docs/dev/workflows.md
@@ -28,7 +28,5 @@ $ cd /opt/conda-src
 $ CONDA_SOLVER=libmamba pytest
 ```
 
-Note we [deselect some upstream tests in our `pyproject.toml`](../../pyproject.toml) for a number of reasons.
-The CI workflows override `conda`'s pytest settings in `setup.cfg` with the ones present in`conda-libmamba-solver`'s `pyproject.toml`.
-This allows us to apply the ignored filters automatically.
-You can replace the files as well in your debugging sessions, but remember to revert once you are done!
+Note we [deselect some upstream tests in our `pyproject.toml`](../../dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py) for a number of reasons.
+For this to work we need to ensure that `pytest` loads that plugin by installing it in the same environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,79 +53,12 @@ exclude = '''
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = [
-  ### Original settings from conda/conda
-  "--ignore=setup.py",
-  "--ignore=conda/__main__.py",
-  "--ignore=conda/_vendor",
-  "--ignore=tests/conda_env/specs/test_binstar.py",
-  "--ignore=tests/conda_env/support",
-  "--ignore=tests/conda_env/utils/test_uploader.py",
-  "--ignore=test_data",
   "--tb=native",
   "--strict-markers",
   "--xdoctest-modules",
   "--xdoctest-style=google",
-  ### Deselect tests from conda/conda we cannot pass due to different reasons
-  ### These used to be skipped or xfail'd upstream, but we are trying to
-  ### keep it clean from this project's specifics
-  # This test checks for plugin errors and assumes none are present, but
-  # conda-libmamba-solver counts as one so we need to skip it.
-  "--deselect=tests/plugins/test_manager.py::test_load_entrypoints_importerror",
-  # Conflict report / analysis is done differently with libmamba.
-  "--deselect=tests/cli/test_cli_install.py::test_find_conflicts_called_once",
-  # SolverStateContainer needed
-  "--deselect=tests/core/test_solve.py::test_solve_2",
-  "--deselect=tests/core/test_solve.py::test_virtual_package_solver",
-  "--deselect=tests/core/test_solve.py::test_broken_install",
-  # Features / nomkl involved
-  "--deselect=tests/core/test_solve.py::test_features_solve_1",
-  "--deselect=tests/core/test_solve.py::test_prune_1",
-  "--deselect=tests/test_create.py::test_remove_features",
-  # Inconsistency analysis not implemented yet
-  "--deselect=tests/test_create.py::test_conda_recovery_of_pip_inconsistent_env",
-  # Known bug in mamba; see https://github.com/mamba-org/mamba/issues/1197
-  "--deselect=tests/test_create.py::test_offline_with_empty_index_cache",
-  # The following are known to fail upstream due to too strict expectations
-  # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
-  "--deselect=tests/test_create.py::test_neutering_of_historic_specs",
-  "--deselect=tests/test_create.py::test_pinned_override_with_explicit_spec",
-  "--deselect=tests/core/test_solve.py::test_pinned_1",
-  "--deselect=tests/core/test_solve.py::test_freeze_deps_1",
-  "--deselect=tests/core/test_solve.py::test_cuda_fail_1",
-  "--deselect=tests/core/test_solve.py::test_cuda_fail_2",
-  "--deselect=tests/core/test_solve.py::test_update_all_1",
-  "--deselect=tests/core/test_solve.py::test_conda_downgrade",
-  "--deselect=tests/core/test_solve.py::test_python2_update",
-  "--deselect=tests/core/test_solve.py::test_fast_update_with_update_modifier_not_set",
-  "--deselect=tests/core/test_solve.py::test_downgrade_python_prevented_with_sane_message",
-  # These use libmamba-incompatible MatchSpecs (name[build_number=1] syntax)
-  "--deselect=tests/models/test_prefix_graph.py::test_deep_cyclical_dependency",
-  # See https://github.com/conda/conda-libmamba-solver/pull/133#issuecomment-1448607110
-  # These failed after enabling the whole unit test suite for `conda/conda`.
-  # Errors are not critical but would require some further assessment in case fixes are obvious.
-  "--deselect=tests/cli/test_main_notices.py::test_notices_appear_once_when_running_decorated_commands",
-  "--deselect=tests/cli/test_main_notices.py::test_notices_does_not_interrupt_command_on_failure",
-  "--deselect=tests/conda_env/installers/test_pip.py::PipInstallerTest::test_stops_on_exception",
-  "--deselect=tests/conda_env/installers/test_pip.py::PipInstallerTest::test_straight_install",
-  "--deselect=tests/conda_env/specs/test_base.py::DetectTestCase::test_build_msg",
-  "--deselect=tests/conda_env/specs/test_base.py::DetectTestCase::test_dispatches_to_registered_specs",
-  "--deselect=tests/conda_env/specs/test_base.py::DetectTestCase::test_has_build_msg_function",
-  "--deselect=tests/conda_env/specs/test_base.py::DetectTestCase::test_passes_kwargs_to_all_specs",
-  "--deselect=tests/conda_env/specs/test_base.py::DetectTestCase::test_raises_exception_if_no_detection",
-  # TODO: Fix upstream; they seem to assume no other solvers will be active via env var
-  "--deselect=tests/plugins/test_solvers.py::test_get_solver_backend",
-  "--deselect=tests/plugins/test_solvers.py::test_get_solver_backend_multiple",
-  # TODO: Investigate these, since they are solver related-ish
-  "--deselect=tests/conda_env/specs/test_requirements.py::TestRequiremets::test_environment",
-  "--deselect=tests/models/test_prefix_graph.py::test_windows_sort_orders_1",
-  # TODO: These ones need further investigation
-  "--deselect=tests/core/test_solve.py::test_channel_priority_churn_minimized",
-  "--deselect=tests/core/test_solve.py::test_priority_1",
-  # TODO: Investigate why this fails on Windows now
-  "--deselect=tests/test_create.py::test_install_update_deps_only_deps_flags",
-  # TODO: https://github.com/conda/conda-libmamba-solver/issues/141
-  "--deselect=tests/test_create.py::test_conda_pip_interop_conda_editable_package",
 ]
+
 markers = [
   "integration: integration tests that usually require an internet connect",
   "slow: slow running tests",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix a couple issues where a failed scheduled run wouldn't trigger a new issue notifying us of the problem. This PR also revisits the pytest collection from upstream `conda/conda` so we have more control over it; it uses a pytest plugin (`dev/collect_upstream_conda_tests`), which needs to be installed in the same environment as `pytest`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
