### PR TITLE
Do not assume channels are always supplied

### DIFF
--- a/conda_libmamba_solver/mamba_utils.py
+++ b/conda_libmamba_solver/mamba_utils.py
@@ -36,6 +36,9 @@ def set_channel_priorities(index: Dict[str, "_ChannelRepoInfo"], has_priority: b
     This function was part of mamba.utils.load_channels originally.
     We just split it to reuse it a bit better.
     """
+    if not index:
+        return index
+
     if has_priority is None:
         has_priority = context.channel_priority in [
             ChannelPriority.STRICT,

--- a/news/256-empty-index
+++ b/news/256-empty-index
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Handle commands with no channels passed gracefully. (#256)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This command

```
$ conda create -n unused --dry-run --override-channels -c local python
```

will make conda-libmamba-solver crash with:

```
    Traceback (most recent call last):
      File "/opt/conda-src/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
      File "/opt/conda-src/conda/cli/main.py", line 64, in main_subshell
        exit_code = do_call(args, parser)
      File "/opt/conda-src/conda/cli/conda_argparse.py", line 167, in do_call
        result = getattr(module, func_name)(args, parser)
      File "/opt/conda-src/conda/notices/core.py", line 124, in wrapper
        return func(*args, **kwargs)
      File "/opt/conda-src/conda/cli/main_create.py", line 50, in execute
        install(args, parser, "create")
      File "/opt/conda-src/conda/cli/install.py", line 316, in install
        unlink_link_transaction = solver.solve_for_transaction(
      File "/opt/conda-src/conda/core/solve.py", line 154, in solve_for_transaction
        unlink_precs, link_precs = self.solve_for_diff(
      File "/opt/conda-src/conda/core/solve.py", line 215, in solve_for_diff
        final_precs = self.solve_final_state(
      File "/opt/conda-libmamba-solver-src/conda_libmamba_solver/solver.py", line 199, in solve_final_state
        index = IndexHelper(
      File "/opt/conda-libmamba-solver-src/conda_libmamba_solver/index.py", line 125, in __init__
        self._index = self._load_channels()
      File "/opt/conda-libmamba-solver-src/conda_libmamba_solver/index.py", line 285, in _load_channels
        set_channel_priorities(index)
      File "/opt/conda-libmamba-solver-src/conda_libmamba_solver/mamba_utils.py", line 52, in set_channel_priorities
        current_channel = next(iter(index.values())).channel.canonical_name
    StopIteration
```

because we assume `index` will always be populated, but it's not in this case.

The fix is to return `index` early if empty, and we obtain the desired behaviour:

```
Channels:
 - local
Platform: linux-aarch64
Collecting package metadata (repodata.json): done
Solving environment: failed

PackagesNotFoundError: The following packages are not available from current channels:

  - python

Current channels:

  - local

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.
```

This was detected in https://github.com/conda/conda/pull/12984

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
