### PR TITLE
infer missing `noarch` type from subdir and dependencies

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -787,6 +787,12 @@ class LibMambaSolver(Solver):
         kwargs["url"] = join_url(channel_info.full_url, pkg_filename)
         if not kwargs.get("subdir"):  # missing in old channels
             kwargs["subdir"] = channel_info.channel.subdir
+        if kwargs["subdir"] == "noarch":
+            # libmamba doesn't keep 'noarch' type around, so infer for now
+            if any(dep.split()[0] in ("python", "pypy") for dep in kwargs.get("depends", ())):
+                kwargs["noarch"] = "python"
+            else:
+                kwargs["noarch"] = "generic"
         return PackageRecord(**kwargs)
 
     def _check_spec_compat(self, match_spec: MatchSpec) -> MatchSpec:

--- a/news/257-infer-noarch
+++ b/news/257-infer-noarch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Workaround for missing `noarch` field in returned `PackageRecord` payload. (#257)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Needed bit to fix `test_windows_sort_orders_1` upstream. `libmamba` doesn't return the `noarch` field in their JSON payloads carrying the `PackageRecord` kwargs. We will report upstream but for now we can infer the type (more or less) from the subdir and the dependency list.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
