### PR TITLE
lock only if FREEZE_INSTALLED is true

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -533,7 +533,7 @@ class LibMambaSolver(Solver):
                         tasks[("VERIFY", api.SOLVER_VERIFY | api.SOLVER_WEAK)].append(name)
 
         d = dict(tasks)
-        print(json.dumps({k[0]: v for k,v in d.items()}, indent=2))
+        print(json.dumps({k[0]: v for k, v in d.items()}, indent=2))
         return d
 
     def _specs_to_tasks_remove(self, in_state: SolverInputState, out_state: SolverOutputState):

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -520,8 +520,7 @@ class LibMambaSolver(Solver):
                     if python_version_might_change and installed.noarch is None:
                         for dep in installed.depends:
                             if MatchSpec(dep).name in ("python", "python_abi"):
-                                lock = False
-                                verify = False
+                                lock = verify = False
                                 break
                     if lock:
                         tasks[("LOCK", api.SOLVER_LOCK | api.SOLVER_WEAK)].append(

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -532,9 +532,7 @@ class LibMambaSolver(Solver):
                         # see conda/tests/core/test_solve.py::test_force_remove_1
                         tasks[("VERIFY", api.SOLVER_VERIFY | api.SOLVER_WEAK)].append(name)
 
-        d = dict(tasks)
-        print(json.dumps({k[0]: v for k, v in d.items()}, indent=2))
-        return d
+        return dict(tasks)
 
     def _specs_to_tasks_remove(self, in_state: SolverInputState, out_state: SolverOutputState):
         # TODO: Consider merging add/remove in a single logic this so there's no split

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -512,12 +512,10 @@ class LibMambaSolver(Solver):
                     tasks[("ALLOW_UNINSTALL", api.SOLVER_ALLOWUNINSTALL)].append(name)
                 else:
                     # we freeze everything else as installed
-                    lock = True
+                    lock = in_state.update_modifier.FREEZE_INSTALLED
                     if pinned and pinned.is_name_only_spec:
                         # name-only pins are treated as locks when installed
                         lock = True
-                    elif in_state.update_modifier.UPDATE_ALL:
-                        lock = False
                     if python_version_might_change and installed.noarch is None:
                         for dep in installed.depends:
                             if MatchSpec(dep).name in ("python", "python_abi"):

--- a/news/270-tasks-and-prune
+++ b/news/270-tasks-and-prune
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Rewrite how we create tasks for `libsolv`, making use of `libmamba`'s `add_pin` features. (#270)
+* Rewrite how we create tasks for `libsolv`, making use of `libmamba`'s `add_pin` features. (#270, #288)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

I think I missed this bit in #270. By default, conda classic will have the CLI set `--freeze-installed` for you, and then remove it if it didn't work. In libmamba, we remove it ourselves progressively as things conflict to avoid a 2nd solver instantiation and the overhead. However, in 270 we were always locking deps; there was no way to override that decision (in classic you do it by passing `--update-specs`). This should implement the same behavior without breaking anything. Let's see 🤞 
