### PR TITLE
only apply `defaults::x` workaround when `default_channels` has not been customized

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -20,7 +20,13 @@ from typing import Iterable, Mapping, Optional, Sequence, Union
 import libmambapy as api
 from boltons.setutils import IndexedSet
 from conda import __version__ as _conda_version
-from conda.base.constants import REPODATA_FN, UNKNOWN_CHANNEL, ChannelPriority, on_win
+from conda.base.constants import (
+    DEFAULT_CHANNELS,
+    REPODATA_FN,
+    UNKNOWN_CHANNEL,
+    ChannelPriority,
+    on_win,
+)
 from conda.base.context import context
 from conda.common.constants import NULL
 from conda.common.io import Spinner, timeout
@@ -921,7 +927,10 @@ class LibMambaSolver(Solver):
                 f"You can only use {supported}, but you tried to use "
                 f"{tuple(unsupported_but_set)}.",
             )
-        if match_spec.get_raw_value("channel") == "defaults":
+        if (
+            match_spec.get_raw_value("channel") == "defaults"
+            and context.default_channels == DEFAULT_CHANNELS
+        ):
             # !!! Temporary !!!
             # Apply workaround for defaults::pkg-name specs.
             # We need to replace it with the actual channel name (main, msys2, r)

--- a/news/292-defaults
+++ b/news/292-defaults
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Only apply `defaults::pkg` workarounds for the default value `default_channels`. (#292)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Our `defaults::x` workarounds that translate the multichannel to the relevant `pkgs/*` channel should only apply when `defaults` has not been redefined in the user configuration via `default_channels`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
