### PR TITLE
Allow only CLI specs as long as compatible with pins

### DIFF
--- a/conda_libmamba_solver/exceptions.py
+++ b/conda_libmamba_solver/exceptions.py
@@ -1,16 +1,9 @@
 # Copyright (C) 2022 Anaconda, Inc
 # Copyright (C) 2023 conda
 # SPDX-License-Identifier: BSD-3-Clause
-import os
 import sys
-from textwrap import dedent
 
-from conda.common.io import dashlist
-from conda.exceptions import (
-    CondaError,
-    SpecsConfigurationConflictError,
-    UnsatisfiableError,
-)
+from conda.exceptions import UnsatisfiableError
 
 
 class LibMambaUnsatisfiableError(UnsatisfiableError):
@@ -20,44 +13,6 @@ class LibMambaUnsatisfiableError(UnsatisfiableError):
 
     def __init__(self, message, **kwargs):
         super(UnsatisfiableError, self).__init__(str(message))
-
-
-class RequestedAndPinnedError(SpecsConfigurationConflictError):
-    """
-    Raised when a spec is both requested and pinned.
-    """
-
-    def __init__(self, requested_specs, pinned_specs, prefix):
-        message = (
-            dedent(
-                """
-                Requested specs overlap with pinned specs.
-                  requested specs: {requested_specs_formatted}
-                  pinned specs: {pinned_specs_formatted}
-
-                Consider adjusting your requested specs to respect the pin(s),
-                or explicitly remove the offending pin(s) from the configuration.
-                Use 'conda config --show-sources' to look for 'pinned_specs'.
-                Pinned specs may also be defined in the file
-                {pinned_specs_path}.
-                """
-            )
-            .strip()
-            .format(
-                requested_specs_formatted=dashlist(requested_specs, 4),
-                pinned_specs_formatted=dashlist(pinned_specs, 4),
-                pinned_specs_path=os.path.join(prefix, "conda-meta", "pinned"),
-            )
-        )
-        # skip SpecsConfigurationConflictError.__init__ but subclass from it
-        # to benefit from the try/except logic in the CLI layer
-        CondaError.__init__(
-            self,
-            message,
-            requested_specs=requested_specs,
-            pinned_specs=pinned_specs,
-            prefix=prefix,
-        )
 
 
 if "conda_build" in sys.modules:

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -713,7 +713,7 @@ class SolverOutputState:
                 # and let the user override pins in the CLI. libmamba doesn't allow
                 # the user to override pins. We will have raised an exception earlier
                 # We will keep this code here for reference
-                if True: # compatible_specs(index, sis.requested[name], spec):
+                if True:  # compatible_specs(index, sis.requested[name], spec):
                     # assume compatible, we will raise later otherwise
                     reason = (
                         "Pinned, installed and requested; constraining request "
@@ -991,7 +991,7 @@ class SolverOutputState:
 
     def early_exit(self):
         """
-        Operations that do not need a solver and might result in returning 
+        Operations that do not need a solver and might result in returning
         early are collected here.
         """
         sis = self.solver_input_state
@@ -1003,7 +1003,7 @@ class SolverOutputState:
                 exc = PackagesNotFoundError(not_installed)
                 exc.allow_retry = False
                 raise exc
-        
+
             if sis.force_remove:
                 for name, spec in sis.requested.items():
                     for record in sis.installed.values():

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -963,12 +963,13 @@ class SolverOutputState:
         for name in requested_and_pinned:
             requested = sis.requested[name]
             pin = sis.pinned[name]
-            if pin.is_name_only_spec:
-                installed = sis.installed.get(name)
-                if installed:
-                    pin = installed.to_match_spec()
-            if not compatible_specs(index, (requested, pin)):
-                # No records in common -> raise
+            installed = sis.installed.get(name)
+            if (
+                # name-only pins lock to installed; requested spec must match it
+                (pin.is_name_only_spec and installed and not requested.match(installed))
+                # otherwise, the pin needs to be compatible with the requested spec
+                or not compatible_specs(index, (requested, pin))
+            ):
                 pinned_specs = [
                     (sis.installed.get(name, pin) if pin.is_name_only_spec else pin)
                     for name, pin in sorted(sis.pinned.items())

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -57,6 +57,7 @@ def is_channel_available(channel_url) -> bool:
         log.debug("Failed to check if channel %s is available", channel_url, exc_info=exc)
         return False
 
+
 def compatible_specs(index, specs, raise_not_found=True):
     """
     Assess whether the given specs are compatible with each other.
@@ -70,7 +71,7 @@ def compatible_specs(index, specs, raise_not_found=True):
     """
     if not len(specs) >= 2:
         raise ValueError("Must specify at least two specs")
-    
+
     matched = None
     for spec in specs:
         results = set(index.search(str(spec)))
@@ -88,5 +89,5 @@ def compatible_specs(index, specs, raise_not_found=True):
         matched &= results
         if not matched:
             return False
-    
+
     return bool(matched)

--- a/conda_libmamba_solver/utils.py
+++ b/conda_libmamba_solver/utils.py
@@ -55,3 +55,21 @@ def is_channel_available(channel_url) -> bool:
     except Exception as exc:
         log.debug("Failed to check if channel %s is available", channel_url, exc_info=exc)
         return False
+
+def compatible_specs(index, *specs):
+    """
+    Assess whether the given specs are compatible with each other.
+    This is done by querying the index for each spec and taking the
+    intersection of the results. If the intersection is empty, the
+    specs are incompatible.
+    """
+    if not len(specs) >= 2:
+        raise ValueError("Must specify at least two specs")
+    
+    matched = set(index.search(str(specs[0])))
+    for spec in specs[1:]:
+        matched &= set(index.search(str(spec)))
+        if not matched:
+            break
+    
+    return bool(matched)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -357,7 +357,8 @@ def test_constraining_pin_and_requested():
 
 
 def test_locking_pins():
-    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib") as prefix:
+    channels = ("--override-channels", "-c", "conda-forge")
+    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib", *channels) as prefix:
         # Should install just fine
         zlib = PrefixData(prefix).get("zlib")
         assert zlib
@@ -367,6 +368,7 @@ def test_locking_pins():
             "install",
             prefix,
             "zlib=1.2.11",
+            *channels,
             "--dry-run",
             "--json",
             use_exception_handler=True,

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -357,7 +357,7 @@ def test_constraining_pin_and_requested():
 
 
 def test_locking_pins():
-    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib", ) as prefix:
+    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib") as prefix:
         # Should install just fine
         zlib = PrefixData(prefix).get("zlib")
         assert zlib

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -357,8 +357,7 @@ def test_constraining_pin_and_requested():
 
 
 def test_locking_pins():
-    channels = ("--override-channels", "-c", "conda-forge")
-    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib", *channels) as prefix:
+    with env_var("CONDA_PINNED_PACKAGES", "zlib"), make_temp_env("zlib", ) as prefix:
         # Should install just fine
         zlib = PrefixData(prefix).get("zlib")
         assert zlib
@@ -368,7 +367,6 @@ def test_locking_pins():
             "install",
             prefix,
             "zlib=1.2.11",
-            *channels,
             "--dry-run",
             "--json",
             use_exception_handler=True,

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -276,7 +276,7 @@ def test_pinned_with_cli_build_string():
         )
         data = json.loads(p.stdout)
         assert not data.get("success")
-        assert data["exception_name"] == "RequestedAndPinnedError"
+        assert data["exception_name"] == "SpecsConfigurationConflictError"
 
         # Adding name only specs is the same as requesting
         # the pins explicitly, which should be a no-op
@@ -320,7 +320,7 @@ def test_constraining_pin_and_requested():
     )
     data = json.loads(p.stdout)
     assert not data.get("success")
-    assert data["exception_name"] == "RequestedAndPinnedError"
+    assert data["exception_name"] == "SpecsConfigurationConflictError"
 
     # This is ok because it's a no-op
     p = conda_subprocess(
@@ -351,7 +351,7 @@ def test_locking_pins():
         )
         data = json.loads(out)
         assert retcode
-        assert data["exception_name"] == "RequestedAndPinnedError"
+        assert data["exception_name"] == "SpecsConfigurationConflictError"
         assert str(zlib) in data["error"]
 
         # This is a no-op and ok. It won't involve changes.

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -244,15 +244,17 @@ def test_too_aggressive_update_to_conda_forge_packages():
 @pytest.mark.skipif(context.subdir != "linux-64", reason="Linux-64 only")
 def test_pinned_with_cli_build_string():
     """ """
-    cmd = (
+    specs = (
         "scipy=1.7.3=py37hf2a6cf1_0",
         "python=3.7.3",
         "pandas=1.2.5=py37h295c915_0",
+    )
+    channels = (
         "--override-channels",
         "--channel=conda-forge",
         "--channel=defaults",
     )
-    with make_temp_env(*cmd) as prefix:
+    with make_temp_env(*specs, *channels) as prefix:
         Path(prefix, "conda-meta").mkdir(exist_ok=True)
         Path(prefix, "conda-meta", "pinned").write_text(
             dedent(
@@ -263,40 +265,55 @@ def test_pinned_with_cli_build_string():
                 """
             ).lstrip()
         )
-        # Note we raise even if the specs are the same as the pins
+        # We ask for the same packages or name-only, it should be compatible
+        for valid_specs in (specs, ("python", "pandas", "scipy")):
+            p = conda_subprocess(
+                "install",
+                "-p",
+                prefix,
+                *valid_specs,
+                *channels,
+                "--dry-run",
+                "--json",
+                explain=True,
+                check=False,
+            )
+            data = json.loads(p.stdout)
+            assert data.get("success")
+            assert data["message"] == "All requested packages already installed."
+
+        # However if we ask for a different version, it should fail
+        invalid_specs = ("python=3.8", "pandas=1.2.4", "scipy=1.7.2")
         p = conda_subprocess(
-            "install",
-            "-p",
-            prefix,
-            *cmd,
-            "--dry-run",
-            "--json",
-            explain=True,
-            check=False,
-        )
+                "install",
+                "-p",
+                prefix,
+                *invalid_specs,
+                *channels,
+                "--dry-run",
+                "--json",
+                explain=True,
+                check=False,
+            )
         data = json.loads(p.stdout)
         assert not data.get("success")
         assert data["exception_name"] == "SpecsConfigurationConflictError"
-
-        # Adding name only specs is the same as requesting
-        # the pins explicitly, which should be a no-op
+        
+        non_existing_specs = ("python=0", "pandas=1000", "scipy=24")
         p = conda_subprocess(
-            "install",
-            "-p",
-            prefix,
-            "python",
-            "pandas",
-            "scipy",
-            "--override-channels",
-            "--channel=conda-forge",
-            "--channel=defaults",
-            "--dry-run",
-            "--json",
-            explain=True,
-        )
+                "install",
+                "-p",
+                prefix,
+                *non_existing_specs,
+                *channels,
+                "--dry-run",
+                "--json",
+                explain=True,
+                check=False,
+            )
         data = json.loads(p.stdout)
-        assert data.get("success")
-        assert data.get("message") == "All requested packages already installed."
+        assert not data.get("success")
+        assert data["exception_name"] == "PackagesNotFoundError"
 
 
 def test_constraining_pin_and_requested():
@@ -347,7 +364,12 @@ def test_locking_pins():
 
         # This should fail because it contradicts the lock packages
         out, err, retcode = run_command(
-            "install", prefix, "zlib=1.2.11", "--dry-run", "--json", use_exception_handler=True
+            "install",
+            prefix,
+            "zlib=1.2.11",
+            "--dry-run",
+            "--json",
+            use_exception_handler=True,
         )
         data = json.loads(out)
         assert retcode

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -285,32 +285,32 @@ def test_pinned_with_cli_build_string():
         # However if we ask for a different version, it should fail
         invalid_specs = ("python=3.8", "pandas=1.2.4", "scipy=1.7.2")
         p = conda_subprocess(
-                "install",
-                "-p",
-                prefix,
-                *invalid_specs,
-                *channels,
-                "--dry-run",
-                "--json",
-                explain=True,
-                check=False,
-            )
+            "install",
+            "-p",
+            prefix,
+            *invalid_specs,
+            *channels,
+            "--dry-run",
+            "--json",
+            explain=True,
+            check=False,
+        )
         data = json.loads(p.stdout)
         assert not data.get("success")
         assert data["exception_name"] == "SpecsConfigurationConflictError"
-        
+
         non_existing_specs = ("python=0", "pandas=1000", "scipy=24")
         p = conda_subprocess(
-                "install",
-                "-p",
-                prefix,
-                *non_existing_specs,
-                *channels,
-                "--dry-run",
-                "--json",
-                explain=True,
-                check=False,
-            )
+            "install",
+            "-p",
+            prefix,
+            *non_existing_specs,
+            *channels,
+            "--dry-run",
+            "--json",
+            explain=True,
+            check=False,
+        )
         data = json.loads(p.stdout)
         assert not data.get("success")
         assert data["exception_name"] == "PackagesNotFoundError"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Extends #289 to allow CLI specs compatible with pins. It will still reject incompatible ones, with the standard `SpecsConfigurationConflictError`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
