### PR TITLE
Fix solve dance caused by verification tasks

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -523,23 +523,18 @@ class LibMambaSolver(Solver):
                 else:
                     # we freeze everything else as installed
                     lock = in_state.update_modifier.FREEZE_INSTALLED
-                    verify = True
                     if pinned and pinned.is_name_only_spec:
                         # name-only pins are treated as locks when installed
                         lock = True
                     if python_version_might_change and installed.noarch is None:
                         for dep in installed.depends:
                             if MatchSpec(dep).name in ("python", "python_abi"):
-                                lock = verify = False
+                                lock = False
                                 break
                     if lock:
                         tasks[("LOCK", api.SOLVER_LOCK | api.SOLVER_WEAK)].append(
                             installed_spec_str
                         )
-                    if verify:
-                        # without verify, solves after a force-remove do not restore missing pkg
-                        # see conda/tests/core/test_solve.py::test_force_remove_1
-                        tasks[("VERIFY", api.SOLVER_VERIFY | api.SOLVER_WEAK)].append(name)
 
         return dict(tasks)
 

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -32,8 +32,8 @@ _deselected_upstream_tests = {
         # classic expects implicit update to channel with higher priority, including downgrades
         # libmamba does not do this, it just stays in the same channel; should it change?
         "test_priority_1",
-        # FIXME: Known issue: We can use a VERIFY task, but that causes a "dance" across solves, where
-        # the verification task changes a few specs. Next time it runs it undoes it.
+        # FIXME: Known issue: We can use a VERIFY task, but that causes a "dance" across solves,
+        # where the verification task changes a few specs. Next time it runs it undoes it.
         "test_force_remove_1",
         # The following are known to fail upstream due to too strict expectations
         # We provide the same tests with adjusted checks in tests/test_modified_upstream.py

--- a/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
+++ b/dev/collect_upstream_conda_tests/collect_upstream_conda_tests.py
@@ -32,6 +32,9 @@ _deselected_upstream_tests = {
         # classic expects implicit update to channel with higher priority, including downgrades
         # libmamba does not do this, it just stays in the same channel; should it change?
         "test_priority_1",
+        # FIXME: Known issue: We can use a VERIFY task, but that causes a "dance" across solves, where
+        # the verification task changes a few specs. Next time it runs it undoes it.
+        "test_force_remove_1",
         # The following are known to fail upstream due to too strict expectations
         # We provide the same tests with adjusted checks in tests/test_modified_upstream.py
         "test_pinned_1",

--- a/news/302-solve-dance
+++ b/news/302-solve-dance
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Prevent solver from bouncing between two compatible solutions when the same command is run twice in a row. (#302)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I've seen an issue with the verification task in two instances after upgrading to 23.9.0:

- In my `base` environment, it insisted on downgrading Python 3.9.14 to 3.9.9. I requested 3.9.14 again, it installed. But running `conda install conda-libmamba-solver=23.9.0` (which should be a no-op, because it's already there), asked for the Python downgrade.
- In a `grayskull` environment, I ran `conda update --all` and it successfully updated everything. Running it again, asked for a slightly different solve. A third time, it undid the previous one. And so on: it keeps bouncing between two solutions.

Since this is not ideal, I suggest we remove the verification task (which is only needed to "repair" a force removal) until we learn more about. It'd be a good moment to do proper consistency checks _before_ handling the install request, as conda classic does.

<details>

<summary>Dance logs</summary>

```shell
(base)  $ conda activate grayskull
(grayskull)  $ conda update --all
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    brotlipy-0.7.0             |py310h2aa6e3c_1006         307 KB  conda-forge
    cffi-1.15.1                |  py310hdcd7c05_5         224 KB  conda-forge
    cryptography-41.0.4        |  py310hdd3b5e7_0         1.2 MB  conda-forge
    docutils-0.20.1            |  py310hbe9552e_2         707 KB  conda-forge
    grayskull-2.5.0            |     pyhd8ed1ab_0          85 KB  conda-forge
    libblas-3.9.0              |18_osxarm64_openblas          15 KB  conda-forge
    libcblas-3.9.0             |18_osxarm64_openblas          14 KB  conda-forge
    libgfortran-5.0.0          |13_2_0_hd922786_1         108 KB  conda-forge
    libgfortran5-13.2.0        |       hf226fd6_1         972 KB  conda-forge
    liblapack-3.9.0            |18_osxarm64_openblas          14 KB  conda-forge
    libopenblas-0.3.24         |openmp_hd76b1f2_0         2.7 MB  conda-forge
    markupsafe-2.1.3           |  py310h2aa6e3c_1          23 KB  conda-forge
    numpy-1.26.0               |  py310he2cad68_0         5.3 MB  conda-forge
    python_abi-3.10            |          4_cp310           6 KB  conda-forge
    rapidfuzz-3.3.1            |  py310h1253130_0         795 KB  conda-forge
    ------------------------------------------------------------
                                           Total:        12.4 MB

The following NEW packages will be INSTALLED:

  brotli-python      conda-forge/osx-arm64::brotli-python-1.1.0-py310h1253130_0 
  libexpat           conda-forge/osx-arm64::libexpat-2.5.0-hb7217d7_1 
  typing_extensions  conda-forge/noarch::typing_extensions-4.8.0-pyha770c72_0 

The following packages will be UPDATED:

  alabaster                                     0.7.12-py_0 --> 0.7.13-pyhd8ed1ab_0 
  babel                                  2.9.1-pyh44b312d_0 --> 2.12.1-pyhd8ed1ab_1 
  brotlipy                         0.7.0-py310h8e9501a_1005 --> 0.7.0-py310h2aa6e3c_1006 
  c-ares                                  1.18.1-h3422bc3_0 --> 1.19.1-hb547adb_0 
  ca-certificates                      2022.12.7-h4653dfc_0 --> 2023.7.22-hf0a4a13_0 
  certifi                            2022.12.7-pyhd8ed1ab_0 --> 2023.7.22-pyhd8ed1ab_0 
  cffi                               1.15.1-py310h2399d43_3 --> 1.15.1-py310hdcd7c05_5 
  charset-normalizer                     3.1.0-pyhd8ed1ab_0 --> 3.2.0-pyhd8ed1ab_0 
  cryptography                       40.0.2-py310hfc83b78_0 --> 41.0.4-py310hdd3b5e7_0 
  curl                                     8.0.1-heffe338_0 --> 8.3.0-hc52a3a8_0 
  docutils                           0.17.1-py310hbe9552e_1 --> 0.20.1-py310hbe9552e_2 
  expat                                    2.4.4-hbdafb3b_0 --> 2.5.0-hb7217d7_1 
  gettext                            0.19.8.1-h049c9fb_1008 --> 0.21.1-h0186832_0 
  git                               2.35.0-pl5321hfe47735_0 --> 2.42.0-pl5321h46e2b6d_0 
  grayskull                              2.3.0-pyhd8ed1ab_1 --> 2.5.0-pyhd8ed1ab_0 
  imagesize                              1.3.0-pyhd8ed1ab_0 --> 1.4.1-pyhd8ed1ab_0 
  importlib-metadata conda-forge/osx-arm64::importlib-meta~ --> conda-forge/noarch::importlib-metadata-6.8.0-pyha770c72_0 
  jinja2                                 3.0.3-pyhd8ed1ab_0 --> 3.1.2-pyhd8ed1ab_1 
  krb5                                    1.20.1-h69eda48_0 --> 1.21.2-h92f50d5_0 
  libblas                        3.9.0-16_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libcblas                       3.9.0-16_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libcurl                                  8.0.1-heffe338_0 --> 8.3.0-hc52a3a8_0 
  libcxx                                  16.0.1-h75e25f2_0 --> 16.0.6-h4653b0c_0 
  libgfortran5                           12.2.0-h0eea778_31 --> 13.2.0-hf226fd6_1 
  libiconv                                  1.16-h642e427_0 --> 1.17-he4db4b2_0 
  liblapack                      3.9.0-16_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libopenblas                      0.3.21-openmp_hc731615_3 --> 0.3.24-openmp_hd76b1f2_0 
  libsqlite                               3.40.0-h76d750c_0 --> 3.43.0-hb31c410_0 
  libssh2                                 1.10.0-h7a5bd25_3 --> 1.11.0-h7a5bd25_0 
  libzlib                                 1.2.13-h03a7124_4 --> 1.2.13-h53f4e23_5 
  llvm-openmp                             16.0.1-h7cfbb63_0 --> 16.0.6-h1c12783_0 
  markupsafe                          2.0.1-py310he2143c4_1 --> 2.1.3-py310h2aa6e3c_1 
  ncurses                                    6.3-h07bb92c_1 --> 6.4-h7ea286d_0 
  numpy                              1.24.2-py310h3d2048e_0 --> 1.26.0-py310he2cad68_0 
  openssl                                  3.1.0-h03a7124_0 --> 3.1.3-h53f4e23_0 
  pcre2                                    10.37-hc5de063_0 --> 10.40-hb34f9b4_0 
  perl                              5.32.1-1_h9b22ae9_perl5 --> 5.32.1-4_hf2054a2_perl5 
  pip                                     23.1-pyhd8ed1ab_0 --> 23.2.1-pyhd8ed1ab_0 
  pygments                              2.11.2-pyhd8ed1ab_0 --> 2.16.1-pyhd8ed1ab_0 
  pyopenssl                             23.1.1-pyhd8ed1ab_0 --> 23.2.0-pyhd8ed1ab_1 
  pyparsing                              3.0.7-pyhd8ed1ab_0 --> 3.1.1-pyhd8ed1ab_0 
  python-utils                           3.5.2-pyhd8ed1ab_0 --> 3.8.1-pyhd8ed1ab_0 
  python_abi                                   3.10-3_cp310 --> 3.10-4_cp310 
  pytz                                  2021.3-pyhd8ed1ab_0 --> 2023.3.post1-pyhd8ed1ab_0 
  rapidfuzz                           3.0.0-py310h0f1eb42_0 --> 3.3.1-py310h1253130_0 
  requests                              2.28.2-pyhd8ed1ab_1 --> 2.31.0-pyhd8ed1ab_0 
  ruamel.yaml                       0.17.21-py310h8e9501a_3 --> 0.17.32-py310h2aa6e3c_0 
  semver                                2.13.0-pyh9f0ad1d_0 --> 3.0.1-pyhd8ed1ab_0 
  setuptools                            67.6.1-pyhd8ed1ab_0 --> 68.2.2-pyhd8ed1ab_0 
  soupsieve                        2.3.2.post1-pyhd8ed1ab_0 --> 2.5-pyhd8ed1ab_1 
  sphinx                                 4.4.0-pyh6c4a22f_1 --> 7.2.6-pyhd8ed1ab_0 
  sphinxcontrib-app~                             1.0.2-py_0 --> 1.0.7-pyhd8ed1ab_0 
  sphinxcontrib-dev~                             1.0.2-py_0 --> 1.0.5-pyhd8ed1ab_0 
  sphinxcontrib-htm~                     2.0.0-pyhd8ed1ab_0 --> 2.0.4-pyhd8ed1ab_0 
  sphinxcontrib-qth~                             1.0.3-py_0 --> 1.0.6-pyhd8ed1ab_0 
  sphinxcontrib-ser~                     1.1.5-pyhd8ed1ab_1 --> 1.1.9-pyhd8ed1ab_0 
  sqlite                                  3.37.0-h72a2b83_0 --> 3.43.0-h203b68d_0 
  tk                                      8.6.12-he1e0b03_0 --> 8.6.13-hb31c410_0 
  urllib3                              1.26.15-pyhd8ed1ab_0 --> 2.0.5-pyhd8ed1ab_0 
  wheel                                 0.40.0-pyhd8ed1ab_0 --> 0.41.2-pyhd8ed1ab_0 
  zipp                                   3.7.0-pyhd8ed1ab_1 --> 3.17.0-pyhd8ed1ab_0 
  zlib                                    1.2.13-h03a7124_4 --> 1.2.13-h53f4e23_5 
  zstd                                     1.5.2-hf913c23_6 --> 1.5.5-h4f39d0f_0 

The following packages will be DOWNGRADED:

  libgfortran                      5.0.0-12_2_0_hd922786_31 --> 5.0.0-13_2_0_hd922786_1 
  sphinxcontrib-jsm~                             1.0.1-py_0 --> 1.0.1-pyhd8ed1ab_0 


Proceed ([y]/n)? 


Downloading and Extracting Packages
                                                                                                                                                             
Preparing transaction: done                                                                                                                                  
Verifying transaction: done                                                                                                                                  
Executing transaction: done                                                                                                                                  
(grayskull)  $ conda update --all      
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libgfortran                       5.0.0-13_2_0_hd922786_1 --> 5.0.0-12_2_0_hd922786_32 

The following packages will be DOWNGRADED:

  libblas                        3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libcblas                       3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libgfortran5                            13.2.0-hf226fd6_1 --> 12.2.0-h0eea778_32 
  liblapack                      3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libopenblas                      0.3.24-openmp_hd76b1f2_0 --> 0.3.23-openmp_hc731615_0 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all      
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libblas                        3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libcblas                       3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libgfortran5                           12.2.0-h0eea778_32 --> 13.2.0-hf226fd6_1 
  liblapack                      3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libopenblas                      0.3.23-openmp_hc731615_0 --> 0.3.24-openmp_hd76b1f2_0 

The following packages will be DOWNGRADED:

  libgfortran                      5.0.0-12_2_0_hd922786_32 --> 5.0.0-13_2_0_hd922786_1 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libgfortran                       5.0.0-13_2_0_hd922786_1 --> 5.0.0-12_2_0_hd922786_32 

The following packages will be DOWNGRADED:

  libblas                        3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libcblas                       3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libgfortran5                            13.2.0-hf226fd6_1 --> 12.2.0-h0eea778_32 
  liblapack                      3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libopenblas                      0.3.24-openmp_hd76b1f2_0 --> 0.3.23-openmp_hc731615_0 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all                                                      
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libblas                        3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libcblas                       3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libgfortran5                           12.2.0-h0eea778_32 --> 13.2.0-hf226fd6_1 
  liblapack                      3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libopenblas                      0.3.23-openmp_hc731615_0 --> 0.3.24-openmp_hd76b1f2_0 

The following packages will be DOWNGRADED:

  libgfortran                      5.0.0-12_2_0_hd922786_32 --> 5.0.0-13_2_0_hd922786_1 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libgfortran                       5.0.0-13_2_0_hd922786_1 --> 5.0.0-12_2_0_hd922786_32 

The following packages will be DOWNGRADED:

  libblas                        3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libcblas                       3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libgfortran5                            13.2.0-hf226fd6_1 --> 12.2.0-h0eea778_32 
  liblapack                      3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libopenblas                      0.3.24-openmp_hd76b1f2_0 --> 0.3.23-openmp_hc731615_0 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libblas                        3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libcblas                       3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libgfortran5                           12.2.0-h0eea778_32 --> 13.2.0-hf226fd6_1 
  liblapack                      3.9.0-17_osxarm64_openblas --> 3.9.0-18_osxarm64_openblas 
  libopenblas                      0.3.23-openmp_hc731615_0 --> 0.3.24-openmp_hd76b1f2_0 

The following packages will be DOWNGRADED:

  libgfortran                      5.0.0-12_2_0_hd922786_32 --> 5.0.0-13_2_0_hd922786_1 


Proceed ([y]/n)? 


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(grayskull)  $ conda update --all
Channels:
 - conda-forge
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: ~/.local/anaconda/envs/grayskull


The following packages will be UPDATED:

  libgfortran                       5.0.0-13_2_0_hd922786_1 --> 5.0.0-12_2_0_hd922786_32 

The following packages will be DOWNGRADED:

  libblas                        3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libcblas                       3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libgfortran5                            13.2.0-hf226fd6_1 --> 12.2.0-h0eea778_32 
  liblapack                      3.9.0-18_osxarm64_openblas --> 3.9.0-17_osxarm64_openblas 
  libopenblas                      0.3.24-openmp_hd76b1f2_0 --> 0.3.23-openmp_hc731615_0 


Proceed ([y]/n)? n


CondaSystemExit: Exiting.

```

</details>

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
