### PR TITLE
BUG: Account for fact that conda could be pip installed

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -1031,7 +1031,7 @@ class LibMambaSolver(Solver):
             return
 
         # we only want to check if a newer conda is available in the channel we installed it from
-        conda_newer_str = f"{channel_name}::conda>{current_conda_prefix_rec.version}"
+        conda_newer_str = f"{channel_name}::conda>{_conda_version}"
         conda_newer_spec = MatchSpec(conda_newer_str)
 
         # if target prefix is the same conda is running from


### PR DESCRIPTION

Closes #315 

### Description

We should ultimately trust the version that conda reports in `__version__`. Instead we were trusting the prefixdata record which can be wrong if conda is installed in develop mode. This is the same logic that conda classic uses.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
