### PR TITLE
Update recipe to attempt to fix local build failure

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,57 @@
+package:
+  name: "conda-libmamba-solver"
+  version: "{{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}"
+
+source:
+  # git_url is nice in that it won't capture devenv stuff.  However, it only
+  # captures committed code, so pay attention.
+  git_url: ../
+  folder: src/
+
+build:
+  number: 0
+  skip: true  # [py<38]
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  script: {{ PYTHON }} -m pip install src/ -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+    - hatch-vcs
+  run:
+    - python
+    - conda >=23.7.4
+    - libmambapy >=1.5.1
+    - boltons >=23.0.0
+
+test:
+  imports:
+    - conda_libmamba_solver
+  commands:
+    - CONDA_SOLVER=libmamba conda create -n test --dry-run scipy  # [not win]  Not crosss platform.
+    - conda create --solver libmamba -n test --dry-run scipy
+
+about:
+  home: https://github.com/conda/conda-libmamba-solver
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: src/LICENSE
+  summary: 'The fast mamba solver, now in conda!'
+  description: |
+    The conda-libmamba-solver is a new solver for the conda package manager
+    which uses the solver from the mamba project behind the scenes,
+    while carefully implementing conda's functionality and expected behaviors on top.
+    The library used by mamba to do the heavy-lifting is called libsolv.
+  dev_url: https://github.com/conda/conda-libmamba-solver
+  doc_url: https://conda.github.io/conda-libmamba-solver/
+
+extra:
+  recipe-maintainers:
+    - jaimergp
+    - jezdez
+    - wolfv
+  skip-lints:
+    - missing_pip_check


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I wasn't able to conda-build the embedded recipe, not because of noarch. This works better. Still having trouble with hatch, hatch-vcs, and pip's idea of what a valid version number is however.

Also, call pthread_sigmask . I tested this on OSX and you can't press CTRL-C at all without it. It's still unreliable to interrupt download threads but that is being worked on in https://github.com/conda/conda/pull/13246

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
