### PR TITLE
parse "excluded by strict priority" errors as conflicts

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -657,6 +657,9 @@ class LibMambaSolver(Solver):
                 pin_b = words[5].rsplit("-", 1)[0]
                 conflicts.append(MatchSpec(pin_a))
                 conflicts.append(MatchSpec(pin_b))
+            elif "is excluded by strict repo priority" in line:
+                # package python-3.7.6-h0371630_2 is excluded by strict repo priority
+                conflicts.append(cls._str_to_matchspec(words[2]))
             else:
                 log.debug("! Problem line not recognized: %s", line)
 
@@ -736,6 +739,10 @@ class LibMambaSolver(Solver):
             # This error makes 'explain_problems()' crash in libmamba <=1.4.1.
             # Anticipate and return simpler error earlier.
             log.info("Failed to explain problems. Conflicting requests.")
+            return legacy_errors
+        if "is excluded by strict repo priority" in legacy_errors:
+            # This will cause a lot of warnings until implemented in detail explanations
+            log.info("Skipping error explanation. Excluded by strict repo priority.")
             return legacy_errors
         try:
             explained_errors = self.solver.explain_problems()

--- a/news/343-excluded-strict-priority
+++ b/news/343-excluded-strict-priority
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Interpret "excluded by strict priority" solver errors as proper satisfiability conflicts and avoid printing related yet uninformative warnings. (#343)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Part of #341 

We were not parsing this error, which may or may not be involved in the issue mentioned above. We also avoid generating a long explanation for the error because it's not currently supported by libmamba and just results in a few warnings that do not add any more information.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
