### PR TITLE
Make sure conda-forge x linux tests are using latest Docker image (Python 3.11)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,8 @@ jobs:
           - python-version: "3.9"
             default-channel: defaults
           - python-version: "3.10"
+            default-channel: defaults
+          - python-version: "3.11"
             default-channel: conda-forge
 
     env:
@@ -102,11 +104,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
-        default-channel: ["conda-forge"]
         include:
           - python-version: "3.8"
             default-channel: "defaults"
+          - python-version: "3.11"
+            default-channel: "conda-forge"
 
     env:
       OS: "macos"
@@ -200,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.11"]
         default-channel: [conda-forge]
         include:
           - python-version: "3.9"

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -70,17 +70,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # test lower version (w/ defaults) and upper version (w/ defaults and conda-forge)
         default-channel: ['defaults', 'conda-forge']
-        python-version: ['3.8', '3.9', '3.10']
-        conda-subdir: ['win-64']
+        python-version: ['3.8', '3.11']
         test-type: ['unit', 'integration']
         test-group: ['1', '2', '3']
         exclude:
-          # exclude all but one Python version for conda-forge
           - default-channel: 'conda-forge'
-            python-version: '3.9'
-          - default-channel: 'conda-forge'
-            python-version: '3.10'
+            python-version: '3.8'
     env:
       OS: Windows
       PYTHON: ${{ matrix.python-version }}
@@ -208,16 +205,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # test all lower versions (w/ defaults) and upper version (w/ defaults and conda-forge)
         default-channel: ['defaults', 'conda-forge']
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         test-type: ['unit', 'integration']
         test-group: ['1', '2', '3']
         exclude:
-          # exclude all but one Python version for conda-forge
           - default-channel: 'conda-forge'
             python-version: '3.8'
           - default-channel: 'conda-forge'
             python-version: '3.9'
+          - default-channel: 'conda-forge'
+            python-version: '3.10'
     env:
       OS: Linux
       PYTHON: ${{ matrix.python-version }}
@@ -290,7 +289,7 @@ jobs:
       fail-fast: false
       matrix:
         default-channel: ['defaults', 'conda-forge']
-        python-version: ['3.10']
+        python-version: ['3.11']
         platform: ['arm64', 'ppc64le']
     env:
       OS: linux-${{ matrix.platform }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda/conda` started building the Docker images for Linux and conda-forge with Python 3.11 only, so we have not been getting the latest changes for a bit. One of those is the inclusion of `archspec` as a default dependency, which [makes currently open PRs fail](https://github.com/conda/conda-libmamba-solver/actions/runs/6690775866/job/18176751543?pr=340).

Adjusting the CI matrix a bit in this PR too, so it reflects upstream better.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
