### PR TITLE
raise `RuntimeError` produced by `libmambapy.Solver.add_jobs`  as `InvalidSpec` for better error messages

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -37,6 +37,7 @@ from conda.core.prefix_data import PrefixData
 from conda.core.solve import Solver
 from conda.exceptions import (
     InvalidMatchSpec,
+    InvalidSpec,
     PackagesNotFoundError,
     SpecsConfigurationConflictError,
     UnsatisfiableError,
@@ -375,7 +376,10 @@ class LibMambaSolver(Solver):
                     self.solver.add_pin(spec)
                     out_state.pins[f"pin-{n_pins}"] = spec
             else:
-                self.solver.add_jobs(specs, task_type)
+                try:
+                    self.solver.add_jobs(specs, task_type)
+                except RuntimeError as exc:
+                    raise InvalidSpec(str(exc))
 
         # ## Run solver
         solved = self.solver.solve()

--- a/news/357-invalidspec-error
+++ b/news/357-invalidspec-error
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Raise a friendlier `InvalidSpec` error instead of `RuntimeError` when libmamba detects a problem in the configured solver jobs. (#352 via #357)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #352. Instead of the long traceback, we will now get:

```
$ conda install --solver=libmamba numpy
Channels:
 - conda-forge
Platform: linux-aarch64
Collecting package metadata (repodata.json): done
Solving environment: failed

InvalidSpec: The package "conda-forge/linux-64::_openmp_mutex==4.5=2_gnu" is not available for the specified platform
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
