### PR TITLE
Set CONDA_REMOTE_BACKOFF to 2.

### DIFF
--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -84,7 +84,7 @@ jobs:
       CONDA_SUBDIR: ${{ matrix.conda-subdir }}
       TEST_SPLITS: 3
       TEST_GROUP: ${{ matrix.test-group }}
-      CONDA_REMOTE_MAX_RETRIES: 6
+      CONDA_REMOTE_BACKOFF_FACTOR: 2
     steps:
       - name: Checkout conda/conda # CONDA-LIBMAMBA-SOLVER CHANGE
         uses: actions/checkout@v3
@@ -174,7 +174,7 @@ jobs:
         shell: cmd
         env:
           CONDA_SOLVER: libmamba  # CONDA-LIBMAMBA-SOLVER CHANGE
-          CONDA_REMOTE_MAX_RETRIES: 6
+          CONDA_REMOTE_BACKOFF_FACTOR: 2
         run: |
           call .\dev\windows\${{ matrix.test-type }}.bat
 
@@ -246,7 +246,7 @@ jobs:
           # we also added '-e CONDA_SOLVER' to the docker options below
           # changes the paths to the volume(s) (plural, we also need conda-libmamba-solver)
           # and changed the script being run to our vendored copy (last line)
-          CONDA_REMOTE_MAX_RETRIES: 6
+          CONDA_REMOTE_BACKOFF_FACTOR: 2
         run: >
           docker run --rm
           -v ${GITHUB_WORKSPACE}/conda:/opt/conda-src
@@ -254,7 +254,7 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_SOLVER
-          -e CONDA_REMOTE_MAX_RETRIES
+          -e CONDA_REMOTE_BACKOFF_FACTOR
           ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}${{ matrix.default-channel == 'conda-forge' && '-conda-forge' || '' }}
           /opt/conda-libmamba-solver-src/dev/linux/upstream_${{ matrix.test-type }}.sh
 
@@ -459,7 +459,7 @@ jobs:
         working-directory: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
         env:
           CONDA_SOLVER: libmamba  # CONDA-LIBMAMBA-SOLVER CHANGE
-          CONDA_REMOTE_MAX_RETRIES: 6
+          CONDA_REMOTE_BACKOFF_FACTOR: 2
         run: |
           ./dev/macos/${{ matrix.test-type }}.sh
 

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -175,7 +175,7 @@ jobs:
         env:
           CONDA_SOLVER: libmamba  # CONDA-LIBMAMBA-SOLVER CHANGE
           CONDA_REMOTE_MAX_RETRIES: 6
-          run: |
+        run: |
           call .\dev\windows\${{ matrix.test-type }}.bat
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/upstream_tests.yml
+++ b/.github/workflows/upstream_tests.yml
@@ -84,6 +84,7 @@ jobs:
       CONDA_SUBDIR: ${{ matrix.conda-subdir }}
       TEST_SPLITS: 3
       TEST_GROUP: ${{ matrix.test-group }}
+      CONDA_REMOTE_MAX_RETRIES: 6
     steps:
       - name: Checkout conda/conda # CONDA-LIBMAMBA-SOLVER CHANGE
         uses: actions/checkout@v3
@@ -173,7 +174,8 @@ jobs:
         shell: cmd
         env:
           CONDA_SOLVER: libmamba  # CONDA-LIBMAMBA-SOLVER CHANGE
-        run: |
+          CONDA_REMOTE_MAX_RETRIES: 6
+          run: |
           call .\dev\windows\${{ matrix.test-type }}.bat
 
       - uses: codecov/codecov-action@v3
@@ -244,6 +246,7 @@ jobs:
           # we also added '-e CONDA_SOLVER' to the docker options below
           # changes the paths to the volume(s) (plural, we also need conda-libmamba-solver)
           # and changed the script being run to our vendored copy (last line)
+          CONDA_REMOTE_MAX_RETRIES: 6
         run: >
           docker run --rm
           -v ${GITHUB_WORKSPACE}/conda:/opt/conda-src
@@ -251,6 +254,7 @@ jobs:
           -e TEST_SPLITS
           -e TEST_GROUP
           -e CONDA_SOLVER
+          -e CONDA_REMOTE_MAX_RETRIES
           ghcr.io/conda/conda-ci:main-linux-python${{ matrix.python-version }}${{ matrix.default-channel == 'conda-forge' && '-conda-forge' || '' }}
           /opt/conda-libmamba-solver-src/dev/linux/upstream_${{ matrix.test-type }}.sh
 
@@ -455,6 +459,7 @@ jobs:
         working-directory: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
         env:
           CONDA_SOLVER: libmamba  # CONDA-LIBMAMBA-SOLVER CHANGE
+          CONDA_REMOTE_MAX_RETRIES: 6
         run: |
           ./dev/macos/${{ matrix.test-type }}.sh
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Same as gh-351 but using "backoff" instead of more retries:
> This might help with the random connection errors when running the tests.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
