### PR TITLE
Small fix to hide scroll bar on sidebar navigation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,8 @@
+
+/**
+ * This rule is here to avoid the scrollbar appearing this
+ * is not hosted on ReadTheDocs
+ */
+#rtd-footer-container {
+    display: none;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,6 +1,6 @@
 
 /**
- * This rule is here to avoid the scrollbar appearing this
+ * This rule is here to avoid the scrollbar appearing when this
  * is not hosted on ReadTheDocs
  */
 #rtd-footer-container {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ html_theme = "conda_sphinx_theme"
 html_static_path = ["_static"]
 
 html_css_files = [
-    "css/custom.css",
+    "custom.css",
 ]
 
 # Serving the robots.txt since we want to point to the sitemap.xml file


### PR DESCRIPTION
### Description

This is a very small CSS fix that hides the scrollbar on the right side navigation. If this project is ever hosted on ReadTheDocs, we will want to remove this rule.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
