### PR TITLE
Always sort installed records and solver specs

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -407,8 +407,8 @@ class LibMambaSolver(Solver):
             tasks = self._specs_to_tasks_conda_build(in_state, out_state)
         else:
             tasks = self._specs_to_tasks_add(in_state, out_state)
-        print(
-            "Created following tasks:\n",
+        log.debug(
+            "Created following tasks:\n%s",
             json.dumps({k[0]: v for k, v in tasks.items()}, indent=2),
         )
         return tasks

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -408,7 +408,7 @@ class LibMambaSolver(Solver):
         else:
             tasks = self._specs_to_tasks_add(in_state, out_state)
         print(
-            "Created following tasks:\n", 
+            "Created following tasks:\n",
             json.dumps({k[0]: v for k, v in tasks.items()}, indent=2),
         )
         return tasks

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -403,7 +403,7 @@ class LibMambaSolver(Solver):
         log.debug("Creating tasks for %s specs", len(out_state.specs))
         if in_state.is_removing:
             tasks = self._specs_to_tasks_remove(in_state, out_state)
-        if self._called_from_conda_build():
+        elif self._called_from_conda_build():
             tasks = self._specs_to_tasks_conda_build(in_state, out_state)
         else:
             tasks = self._specs_to_tasks_add(in_state, out_state)

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -402,10 +402,16 @@ class LibMambaSolver(Solver):
     def _specs_to_tasks(self, in_state: SolverInputState, out_state: SolverOutputState):
         log.debug("Creating tasks for %s specs", len(out_state.specs))
         if in_state.is_removing:
-            return self._specs_to_tasks_remove(in_state, out_state)
+            tasks = self._specs_to_tasks_remove(in_state, out_state)
         if self._called_from_conda_build():
-            return self._specs_to_tasks_conda_build(in_state, out_state)
-        return self._specs_to_tasks_add(in_state, out_state)
+            tasks = self._specs_to_tasks_conda_build(in_state, out_state)
+        else:
+            tasks = self._specs_to_tasks_add(in_state, out_state)
+        print(
+            "Created following tasks:\n", 
+            json.dumps({k[0]: v for k, v in tasks.items()}, indent=2),
+        )
+        return tasks
 
     @staticmethod
     def _spec_to_str(spec):
@@ -456,7 +462,7 @@ class LibMambaSolver(Solver):
         # logic considers should be the target version for each package in the environment
         # and requested changes. We are _not_ following those targets here, but we do iterate
         # over the list to decide what to do with each package.
-        for name, _classic_logic_spec in out_state.specs.items():
+        for name, _classic_logic_spec in sorted(out_state.specs.items()):
             if name.startswith("__"):
                 continue  # ignore virtual packages
             installed: PackageRecord = in_state.installed.get(name)

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -233,7 +233,7 @@ class SolverInputState:
         can generate an equivalent ``MatchSpec`` object with ``.to_match_spec()``.
         Records are toposorted.
         """
-        return MappingProxyType({pkg.name: pkg for pkg in self.prefix_data.iter_records_sorted()})
+        return MappingProxyType(dict(sorted(self.prefix_data._prefix_records.items())))
 
     @property
     def history(self) -> Mapping[str, MatchSpec]:

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -262,7 +262,7 @@ class SolverInputState:
         cannot be (un)installed, they only represent constrains for other packages. By convention,
         their names start with a double underscore.
         """
-        return MappingProxyType(self._virtual)
+        return MappingProxyType(dict(sorted(self._virtual.items())))
 
     @property
     def aggressive_updates(self) -> Mapping[str, MatchSpec]:

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -231,8 +231,9 @@ class SolverInputState:
         """
         This exposes the installed packages in the prefix. Note that a ``PackageRecord``
         can generate an equivalent ``MatchSpec`` object with ``.to_match_spec()``.
+        Records are toposorted.
         """
-        return MappingProxyType(self.prefix_data._prefix_records)
+        return MappingProxyType({pkg.name: pkg for pkg in self.prefix_data.iter_records_sorted()})
 
     @property
     def history(self) -> Mapping[str, MatchSpec]:
@@ -281,12 +282,14 @@ class SolverInputState:
         - almost all packages if update_all is true
         - etc
         """
-        pkgs = {pkg: MatchSpec(pkg) for pkg in self.aggressive_updates if pkg in self.installed}
+        installed = self.installed
+        pinned = self.pinned
+        pkgs = {pkg: MatchSpec(pkg) for pkg in self.aggressive_updates if pkg in installed}
         if context.auto_update_conda and paths_equal(self.prefix, context.root_prefix):
             pkgs.setdefault("conda", MatchSpec("conda"))
         if self.update_modifier.UPDATE_ALL:
-            for pkg in self.installed:
-                if pkg != "python" and pkg not in self.pinned:
+            for pkg in installed:
+                if pkg != "python" and pkg not in pinned:
                     pkgs.setdefault(pkg, MatchSpec(pkg))
         return MappingProxyType(pkgs)
 

--- a/news/378-sort-installed
+++ b/news/378-sort-installed
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Ensure installed packages are always sorted to avoid injecting accidental randomness in the solve process. (#378)
+* Ensure installed and virtual packages are always sorted to avoid injecting accidental randomness in the solve process. (#378)
 
 ### Deprecations
 

--- a/news/378-sort-installed
+++ b/news/378-sort-installed
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure installed packages are always topologically sorted to avoid injecting accidental randomness in the solve process. (#378)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/378-sort-installed
+++ b/news/378-sort-installed
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Ensure installed and virtual packages are always sorted to avoid injecting accidental randomness in the solve process. (#378)
+* Ensure specs, installed and virtual packages are always sorted to avoid injecting accidental randomness in the solve process. (#378)
 
 ### Deprecations
 

--- a/news/378-sort-installed
+++ b/news/378-sort-installed
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Ensure installed packages are always topologically sorted to avoid injecting accidental randomness in the solve process. (#378)
+* Ensure installed packages are always sorted to avoid injecting accidental randomness in the solve process. (#378)
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->


I've been thinking about some failures we get (only!) sometimes in CI, like `tests/core/test_solve.py::test_conda_downgrade[libmamba]` (see #317). These errors often go away with a retry in the same PR, so there's some randomness at play. 

The hypothesis here is that some container is getting a different order depending on the attempt. `SolverInputState.installed` takes whatever order appears in `PrefixData._prefix_records`, which blindly "takes" whatever `os.scandir()` is returning. This function does not guarantee order, so we are going to switch to a toposorted `installed` container. Maybe this makes the tests behave more reliably?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
