### PR TITLE
Adding conda-sphinx-theme as conda-forge dependency

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - cffi=1.15.1
   - charset-normalizer=2.1.1
   - colorama=0.4.6
+  - conda-sphinx-theme==0.1.3
   - cryptography=38.0.3
   - docutils=0.19
   - idna=3.4
@@ -71,5 +72,3 @@ dependencies:
   - xz=5.2.6
   - yaml=0.2.5
   - zipp=3.10.0
-  - pip:
-      - conda-sphinx-theme==0.1.1


### PR DESCRIPTION
### Description

Now that conda-sphinx-theme is available on conda-forge, let's use it as regular dependency and not a pip dependency.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~