### PR TITLE
use index in offline mode when called from conda-build

### DIFF
--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -411,8 +411,12 @@ class LibMambaIndexHelper(IndexHelper):
 _CachedLibMambaIndexHelper = lru_cache(maxsize=None)(LibMambaIndexHelper)
 
 
-# conda-build needs to operate offline for the index
 def _LibMambaIndexHelperOffline(*args, **kwargs):
+    """
+    conda-build needs to operate offline so the index doesn't get updated
+    accidentally during long build phases.
+
+    See https://github.com/conda/conda-libmamba-solver/issues/386
+    """
     with context._override("offline", True):
-        helper = _CachedLibMambaIndexHelper(*args, **kwargs)
-        return helper
+        return _CachedLibMambaIndexHelper(*args, **kwargs)

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -409,3 +409,10 @@ class LibMambaIndexHelper(IndexHelper):
 
 # for conda-build
 _CachedLibMambaIndexHelper = lru_cache(maxsize=None)(LibMambaIndexHelper)
+
+
+# conda-build needs to operate offline for the index
+def _LibMambaIndexHelperOffline(*args, **kwargs):
+    with context._override("offline", True):
+        helper = _CachedLibMambaIndexHelper(*args, **kwargs)
+        return helper

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -79,6 +79,7 @@ from tempfile import NamedTemporaryFile
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 import libmambapy as api
+from conda import __version__ as conda_version
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
@@ -88,6 +89,7 @@ from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
+from conda.models.version import VersionOrder
 
 from .mamba_utils import set_channel_priorities
 from .state import IndexHelper
@@ -411,12 +413,24 @@ class LibMambaIndexHelper(IndexHelper):
 _CachedLibMambaIndexHelper = lru_cache(maxsize=None)(LibMambaIndexHelper)
 
 
-def _LibMambaIndexHelperOffline(*args, **kwargs):
+def _LibMambaIndexForCondaBuild(*args, **kwargs):
     """
-    conda-build needs to operate offline so the index doesn't get updated
-    accidentally during long build phases.
-
     See https://github.com/conda/conda-libmamba-solver/issues/386
+    
+    conda-build needs to operate offline so the index doesn't get updated
+    accidentally during long build phases. However, this is only guaranteed
+    to work if https://github.com/conda/conda/pull/13357 is applied. Otherwise
+    the condarc configuration might be ignored, resulting in bad index configuration
+    and missing packages anyway.
     """
+    if VersionOrder(conda_version) <= VersionOrder("23.10.0"):
+        log.warning(
+            "conda-build requires conda >=23.11.0 for offline index support. "
+            "Falling back to online index. This might result in KeyError messages, "
+            "specially if the remote repodata is updated during the build phase. "
+            "See https://github.com/conda/conda-libmamba-solver/issues/386."
+        )
+        return _CachedLibMambaIndexHelper(*args, **kwargs)
+    
     with context._override("offline", True):
         return _CachedLibMambaIndexHelper(*args, **kwargs)

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -416,7 +416,7 @@ _CachedLibMambaIndexHelper = lru_cache(maxsize=None)(LibMambaIndexHelper)
 def _LibMambaIndexForCondaBuild(*args, **kwargs):
     """
     See https://github.com/conda/conda-libmamba-solver/issues/386
-    
+
     conda-build needs to operate offline so the index doesn't get updated
     accidentally during long build phases. However, this is only guaranteed
     to work if https://github.com/conda/conda/pull/13357 is applied. Otherwise
@@ -431,6 +431,6 @@ def _LibMambaIndexForCondaBuild(*args, **kwargs):
             "See https://github.com/conda/conda-libmamba-solver/issues/386."
         )
         return _CachedLibMambaIndexHelper(*args, **kwargs)
-    
+
     with context._override("offline", True):
         return _CachedLibMambaIndexHelper(*args, **kwargs)

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -49,7 +49,7 @@ from conda.models.version import VersionOrder
 
 from . import __version__
 from .exceptions import LibMambaUnsatisfiableError
-from .index import LibMambaIndexHelper, _LibMambaIndexHelperOffline
+from .index import LibMambaIndexHelper, _LibMambaIndexForCondaBuild
 from .mamba_utils import init_api_context, mamba_version
 from .state import SolverInputState, SolverOutputState
 from .utils import is_channel_available
@@ -175,7 +175,7 @@ class LibMambaSolver(Solver):
                 rec.channel: None for rec in self._index if rec.channel.scheme == "file"
             }
             # Cache indices for conda-build, it gets heavy otherwise
-            IndexHelper = _LibMambaIndexHelperOffline
+            IndexHelper = _LibMambaIndexForCondaBuild
         else:
             IndexHelper = LibMambaIndexHelper
             conda_bld_channels = ()

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -49,7 +49,7 @@ from conda.models.version import VersionOrder
 
 from . import __version__
 from .exceptions import LibMambaUnsatisfiableError
-from .index import LibMambaIndexHelper, _CachedLibMambaIndexHelper
+from .index import LibMambaIndexHelper, _LibMambaIndexHelperOffline
 from .mamba_utils import init_api_context, mamba_version
 from .state import SolverInputState, SolverOutputState
 from .utils import is_channel_available
@@ -175,7 +175,7 @@ class LibMambaSolver(Solver):
                 rec.channel: None for rec in self._index if rec.channel.scheme == "file"
             }
             # Cache indices for conda-build, it gets heavy otherwise
-            IndexHelper = _CachedLibMambaIndexHelper
+            IndexHelper = _LibMambaIndexHelperOffline
         else:
             IndexHelper = LibMambaIndexHelper
             conda_bld_channels = ()

--- a/news/395-offline-conda-build
+++ b/news/395-offline-conda-build
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Instantiate `IndexHelper` in offline mode for compatibility with conda-build. Otherwise
+  the index can get out of sync during long build processes. (#386 via #395)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/data/conda_build_recipes/stackvana/meta.yaml
+++ b/tests/data/conda_build_recipes/stackvana/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "stackvana-core" %}
+{% set name = "stackvana-split" %}
 {% set version = "0.2021.43" %}
 {% set eups_product = "lsst_distrib" %}
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fixes #386, together with https://github.com/conda/conda/pull/13357.

We need to instantiate `IndexHelper` in offline mode for compatibility with conda-build. Otherwise the index can get out of sync during long build processes.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
