### PR TITLE
`max_attempts` should only use `n_installed` if >0

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -282,7 +282,7 @@ class LibMambaSolver(Solver):
                 return installed_count
             else:
                 return max_attempts_from_env
-        elif in_state.update_modifier.FREEZE_INSTALLED:
+        elif in_state.update_modifier.FREEZE_INSTALLED and installed_count:
             # this the default, but can be overriden with --update-specs
             # we cap at MAX_SOLVER_ATTEMPTS_CAP attempts to avoid things
             # getting too slow in large environments
@@ -335,7 +335,7 @@ class LibMambaSolver(Solver):
                 self._command = "last_solve_attempt"
             else:
                 self._command += "+last_solve_attempt"
-            solved = self._solve_attempt(in_state, out_state, index)
+            solved = self._solve_attempt(in_state, out_state, index, attempt=attempt + 1)
             if not solved:
                 message = self._prepare_problems_message(pins=out_state.pins)
                 exc = LibMambaUnsatisfiableError(message)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Comes from https://github.com/conda/conda-libmamba-solver/pull/381#discussion_r1422379293

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
