### PR TITLE
Refine `MatchSpec` validation to avoid incompatibilities with libmamba's parser

### DIFF
--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -13,7 +13,7 @@ from conda.common.compat import on_linux, on_win
 from conda.common.io import env_vars
 from conda.core.prefix_data import PrefixData
 from conda.models.channel import Channel
-from conda.testing.integration import _get_temp_prefix, make_temp_env
+from conda.testing.integration import _get_temp_prefix, make_temp_env, package_is_installed
 from conda.testing.integration import run_command as conda_inprocess
 
 from .channel_testing.helpers import http_server_auth_basic  # noqa: F401
@@ -298,3 +298,18 @@ def test_http_server_auth_token_in_defaults(http_server_auth_token):
             condarc.write_text(condarc_contents)
         else:
             condarc.unlink()
+
+
+def test_unknown_channels_do_not_crash(tmp_path):
+    "https://github.com/conda/conda-libmamba-solver/issues/418"
+    DATA = Path(__file__).parent / "data"
+    test_pkg = DATA / "mamba_repo" / "noarch" / "test-package-0.1-0.tar.bz2"
+    with make_temp_env("ca-certificates") as prefix:
+        # copy pkg to a new non-channel-like location without repodata around to obtain
+        # '<unknown>' channel and reproduce the issue
+        temp_pkg = Path(prefix, "test-package-0.1-0.tar.bz2")
+        shutil.copy(test_pkg, temp_pkg)
+        conda_inprocess("install", prefix, str(temp_pkg))
+        assert package_is_installed(prefix, "test-package")
+        conda_inprocess("install", prefix, "zlib")
+        assert package_is_installed(prefix, "zlib")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/conda-libmamba-solver/issues/418

We were a bit too strict with some auto-generated `MatchSpec`. The issue above includes an environment where a user has installed a package via URL or path. In this case, `conda` generates a `MatchSpec` object that gets rendered as `package-name[url="package-url"]`.

libmamba only supports _some_ key values in the brackets, so we were rejecting `url` with a `InvalidSpecError`. However, `url` here is superfluous so we can simply drop it from the passed string.

This uncovered a new matchspec that makes libmamba segfault: `<unknown>/noarch::test-package`. We will also anticipate that and drop it before the string is generated because, again, it doesn't add any useful info for the solver and it's only an artifact of not knowing from which channel test-package was installed (because it came from a URL).

Note that _if_ the URL happens to be a channel URL (e.g. `conda.anaconda.org/conda-forge/noarch/package-version-build.tar.bz2`), `conda` DOES recognize it as a valid channel and that doesn't crash. It only reproduces _if_ the tarball is in a non-channel-like location.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
