### PR TITLE
Drop `md5` and `sha256` fields from `MatchSpec` (they are ignored anyway)

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -947,7 +947,7 @@ class LibMambaSolver(Solver):
         if match_spec is None:
             return None
         supported = "name", "version", "build", "channel", "subdir"
-        droppable = ("url",)
+        droppable = ("url", "md5", "sha256")
         unsupported_but_set = []
         to_drop = set()
         to_keep = {}

--- a/news/421-matchspec-validation
+++ b/news/421-matchspec-validation
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Do not raise error if an unsupported `MatchSpec` field can be safely dropped instead. (#418 via #421)
+* Do not raise an error if an unsupported `MatchSpec` field can be safely dropped instead. Currently ignoring `url`, `md5` and `sha256`. (#418 via #421, #427 via #429).
 
 ### Deprecations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #427

libmamba does not die if `md5` fields are passed in the MatchSpec, but it's not used for anything either ([see issue upstream](https://github.com/mamba-org/mamba/issues/2053)). For example, `a4c000a412e65c1844c92c1558257909` corresponds to [linux-aarch64/zlib-1.2.12-h4e544f5_0.tar.bz2](https://anaconda.org/conda-forge/zlib/1.2.12/download/linux-aarch64/zlib-1.2.12-h4e544f5_0.tar.bz2), but we get zlib 1.3 (latest) anyway.

```
$ conda create -dnx "zlib[md5=a4c000a412e65c1844c92c1558257909]"
Channels:
 - conda-forge
Platform: linux-aarch64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/test_user/.conda/envs/x

  added / updated specs:
    - zlib[md5=a4c000a412e65c1844c92c1558257909]


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    _openmp_mutex-4.5          |            2_gnu          23 KB  conda-forge
    libzlib-1.3                |       h31becfc_0          66 KB  conda-forge
    zlib-1.3                   |       h31becfc_0          94 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         184 KB

The following NEW packages will be INSTALLED:

  _openmp_mutex      conda-forge/linux-aarch64::_openmp_mutex-4.5-2_gnu 
  libgcc-ng          conda-forge/linux-aarch64::libgcc-ng-13.2.0-hf8544c7_3 
  libgomp            conda-forge/linux-aarch64::libgomp-13.2.0-hf8544c7_3 
  libzlib            conda-forge/linux-aarch64::libzlib-1.3-h31becfc_0 
  zlib               conda-forge/linux-aarch64::zlib-1.3-h31becfc_0 



DryRunExit: Dry run. Exiting.
```


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
