### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/conda_libmamba_solver/conda_build_exceptions.py
+++ b/conda_libmamba_solver/conda_build_exceptions.py
@@ -25,6 +25,6 @@ class ExplainedDependencyNeedsBuildingError(DependencyNeedsBuildingError):
     def __str__(self) -> str:
         msg = self.message
         if not self.explanation:
-            # print simple message in log.warn() calls
+            # print simple message in log.warning() calls
             return msg
         return "\n".join([msg, self.explanation])

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -278,7 +278,9 @@ class LibMambaIndexHelper(IndexHelper):
             solv_stat = None
 
         if solv_stat is None and json_stat is None:
-            log.warning("No repodata found for channel %s. Solve will fail.", channel.canonical_name)
+            log.warning(
+                "No repodata found for channel %s. Solve will fail.", channel.canonical_name
+            )
             return
         if solv_stat is None:
             path_to_use = json_path

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -278,7 +278,7 @@ class LibMambaIndexHelper(IndexHelper):
             solv_stat = None
 
         if solv_stat is None and json_stat is None:
-            log.warn("No repodata found for channel %s. Solve will fail.", channel.canonical_name)
+            log.warning("No repodata found for channel %s. Solve will fail.", channel.canonical_name)
             return
         if solv_stat is None:
             path_to_use = json_path

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -829,7 +829,7 @@ class LibMambaSolver(Solver):
                     out_state.records.pop(name, None)
                     break
             else:
-                log.warn("Tried to unlink %s but it is not installed or manageable?", filename)
+                log.warning("Tried to unlink %s but it is not installed or manageable?", filename)
 
         for_conda_build = self._called_from_conda_build()
         for channel, filename, json_payload in to_link:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces use of the deprecated `.warn` method of logger objects with `.warning`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
