### PR TITLE
Fix `--satisfied-skip-solve` when spec does not match installed (but name does)

### DIFF
--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -541,10 +541,11 @@ class SolverOutputState:
 
             if sis.force_remove:
                 return force_remove_solution
-
-        if sis.update_modifier.SPECS_SATISFIED_SKIP_SOLVE and not sis.is_removing:
+        elif sis.update_modifier.SPECS_SATISFIED_SKIP_SOLVE:
             for name, spec in sis.requested.items():
                 if name not in sis.installed:
+                    break
+                if not any(spec.match(record) for record in sis.installed.values()):
                     break
             else:
                 # All specs match a package in the current environment.

--- a/news/606-skip
+++ b/news/606-skip
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Consider whether the full spec matches anything installed (not just name) when `--satisfied-skip-solve` is in use. (#605 via #606)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -580,3 +580,10 @@ def test_prune_existing_env_dependencies_are_solved(conda_cli, tmp_path):
         print(out)
         print(err, file=sys.stderr)
         assert rc == 0
+
+
+def test_satisfied_skip_solve_matchspec(conda_cli, tmp_env):
+    with tmp_env("ca-certificates") as prefix:
+        conda_cli(
+            "install", "-p", prefix, "-S", "ca-certificates>10000", raises=PackagesNotFoundError
+        )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #605 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
