### PR TITLE
Replace deprecated testing helpers

### DIFF
--- a/tests/channel_testing/helpers.py
+++ b/tests/channel_testing/helpers.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 
 import pytest
-from conda.testing.integration import _get_temp_prefix, run_command
+from conda.testing.integration import _get_temp_prefix
 from xprocess import ProcessStarter
 
 
@@ -154,18 +154,3 @@ def create_with_channel(
         check=check,
         **kwargs,
     )
-
-
-def create_with_channel_in_process(channel, solver="libmamba", **kwargs) -> tuple[str, str, int]:
-    stdout, stderr, returncode = run_command(
-        "create",
-        _get_temp_prefix(),
-        f"--solver={solver}",
-        "--json",
-        "--override-channels",
-        "-c",
-        channel,
-        "test-package",
-        **kwargs,
-    )
-    return stdout, stderr, returncode

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -7,143 +7,114 @@ Measure the speed and memory usage of the different backend solvers
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from conda.base.context import context
-from conda.common.io import env_var
 from conda.exceptions import DryRunExit
-from conda.testing.integration import Commands, _get_temp_prefix, run_command
 
 if TYPE_CHECKING:
-    from conda.testing.fixtures import TmpEnvFixture
+    from collections.abc import Iterable
 
-platform = context.subdir
+    from conda.testing.fixtures import CondaCLIFixture, TmpEnvFixture
+    from pytest import FixtureRequest
 
-TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+pytestmark = [pytest.mark.slow, pytest.mark.usefixtures("parametrized_solver_fixture")]
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+PLATFORM = context.subdir
 
 
-def _get_channels_from_lockfile(path):
+def _get_channels_from_lockfile(path: Path) -> tuple[str, ...]:
     """Parse `# channels: conda-forge,defaults` comments"""
-    with open(path) as f:
-        for line in f:
-            if line.startswith("# channels:"):
-                return line.split(":")[1].strip().split(",")
+    for line in path.read_text().splitlines():
+        if line.startswith("# channels:"):
+            return tuple(line.split(":")[1].strip().split(","))
+    return ()
 
 
-def _channels_as_args(channels):
-    if not channels:
-        return ()
-    args = ["--override-channels"]
-    for channel in channels:
-        args += ["-c", channel]
-    return tuple(args)
-
-
-def _tmp_prefix_safe():
-    return _get_temp_prefix(use_restricted_unicode=True).replace(" ", "")
+def _get_channel_args(channels: Iterable[str]) -> tuple[str, ...]:
+    return (
+        ("--override-channels", *(f"--channel={channel}" for channel in channels))
+        if channels
+        else ()
+    )
 
 
 @pytest.fixture(
-    scope="module",
-    params=[f for f in os.listdir(TEST_DATA_DIR) if f.endswith(".lock")],
+    scope="session",
+    params=TEST_DATA_DIR.glob("*.lock"),
 )
-def prefix_and_channels(request, session_tmp_env: TmpEnvFixture) -> None:
-    lockfile = os.path.join(TEST_DATA_DIR, request.param)
-    lock_platform = lockfile.split(".")[-2]
-    if lock_platform != platform:
-        pytest.skip(f"Running platform {platform} does not match file platform {lock_platform}")
-    with env_var("CONDA_TEST_SAVE_TEMPS", "1"):
+def prefix_and_channels(
+    request: FixtureRequest,
+    session_tmp_env: TmpEnvFixture,
+) -> Iterable[tuple[Path, tuple[str, ...]]]:
+    lockfile = Path(request.param)
+    lock_platform = lockfile.suffixes[-2]
+    if lock_platform != PLATFORM:
+        pytest.skip(f"Running platform {PLATFORM} does not match file platform {lock_platform}")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("CONDA_TEST_SAVE_TEMPS", "1")
+
         with session_tmp_env("--file", lockfile) as prefix:
             channels = _get_channels_from_lockfile(lockfile)
             yield prefix, channels
 
 
-@pytest.fixture(scope="function", params=["libmamba", "classic"])
-def solver_args(request):
-    yield ("--dry-run", "--solver", request.param)
-
-
-@pytest.mark.slow
-def test_a_warmup(prefix_and_channels, solver_args):
-    """Dummy test to install envs and warm up caches"""
-    prefix_and_channels, solver_args = prefix_and_channels, solver_args
-
-
-@pytest.mark.slow
-def test_update_python(prefix_and_channels, solver_args):
+def test_update_python(
+    prefix_and_channels: tuple[Path, tuple[str, ...]],
+    conda_cli: CondaCLIFixture,
+) -> None:
     prefix, channels = prefix_and_channels
-    try:
-        run_command(
-            Commands.UPDATE,
-            prefix,
-            *_channels_as_args(channels),
-            *solver_args,
-            "python",
-            no_capture=True,
-        )
-    except DryRunExit:
-        assert True
-    else:
-        # this can happen if "all requirements are satisfied"
-        assert True
+    conda_cli(
+        "update",
+        f"--prefix={prefix}",
+        "--dry-run",
+        *_get_channel_args(channels),
+        "python",
+        raises=DryRunExit,
+    )
 
 
-@pytest.mark.slow
-def test_install_python_update_deps(prefix_and_channels, solver_args):
+def test_install_python_update_deps(
+    prefix_and_channels: tuple[Path, tuple[str, ...]],
+    conda_cli: CondaCLIFixture,
+) -> None:
     prefix, channels = prefix_and_channels
-    try:
-        run_command(
-            Commands.INSTALL,
-            prefix,
-            *_channels_as_args(channels),
-            *solver_args,
-            "python",
-            "--update-deps",
-            no_capture=True,
-        )
-    except DryRunExit:
-        assert True
-    else:
-        # this can happen if "all requirements are satisfied"
-        assert True
+    conda_cli(
+        "install",
+        f"--prefix={prefix}",
+        "--dry-run",
+        *_get_channel_args(channels),
+        "python",
+        "--update-deps",
+        raises=DryRunExit,
+    )
 
 
-@pytest.mark.slow
-def test_update_all(prefix_and_channels, solver_args):
+def test_update_all(
+    prefix_and_channels: tuple[Path, tuple[str, ...]],
+    conda_cli: CondaCLIFixture,
+) -> None:
     prefix, channels = prefix_and_channels
-    try:
-        run_command(
-            Commands.UPDATE,
-            prefix,
-            *_channels_as_args(channels),
-            *solver_args,
-            "--all",
-            no_capture=True,
-        )
-    except DryRunExit:
-        assert True
-    else:
-        # this can happen if "all requirements are satisfied"
-        assert True
+    conda_cli(
+        "update",
+        f"--prefix={prefix}",
+        "--dry-run",
+        *_get_channel_args(channels),
+        "--all",
+        raises=DryRunExit,
+    )
 
 
-@pytest.mark.slow
-def test_install_vaex_from_conda_forge_and_defaults(solver_args):
-    try:
-        run_command(
-            Commands.CREATE,
-            _tmp_prefix_safe(),
-            *solver_args,
-            "--override-channels",
-            "-c",
-            "conda-forge",
-            "-c",
-            "defaults",
-            "python=3.9",
-            "vaex",
-            no_capture=True,
-        )
-    except DryRunExit:
-        assert True
+def test_install_vaex_from_conda_forge_and_defaults(conda_cli: CondaCLIFixture) -> None:
+    conda_cli(
+        "create",
+        "--dry-run",
+        *_get_channel_args(["conda-forge", "defaults"]),
+        "python=3.9",
+        "vaex",
+        raises=DryRunExit,
+    )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

A number of testing helpers have been deprecated and are slated for removal in the 25.3 release. Replacing these deprecated helpers (`make_temp_env` and `run_command`) with the new fixtures (`tmp_env` and `conda_cli`).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
