### PR TITLE
Replace `create_with_channel` with `conda_cli` fixture

### DIFF
--- a/tests/channel_testing/helpers.py
+++ b/tests/channel_testing/helpers.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 import os
 import pathlib
 import socket
-import subprocess
 import sys
 
 import pytest
-from conda.testing.integration import _get_temp_prefix
 from xprocess import ProcessStarter
 
 
@@ -130,27 +128,4 @@ def http_server_auth_token(xprocess):
         port=8000,
         auth="token",
         token="xy-12345678-1234-1234-1234-123456789012",
-    )
-
-
-def create_with_channel(
-    channel, solver="libmamba", check=True, **kwargs
-) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "conda",
-            "create",
-            "-p",
-            _get_temp_prefix(),
-            f"--solver={solver}",
-            "--json",
-            "--override-channels",
-            "-c",
-            channel,
-            "test-package",
-        ],
-        check=check,
-        **kwargs,
     )

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -22,7 +22,6 @@ from conda.models.channel import Channel
 from conda.testing.integration import package_is_installed
 
 from .channel_testing.helpers import (
-    create_with_channel,
     http_server_auth_basic,  # noqa: F401
     http_server_auth_basic_email,  # noqa: F401
     http_server_auth_none,  # noqa: F401
@@ -267,20 +266,68 @@ def test_conda_build_with_aliased_channels(tmp_path):
             condarc.unlink()
 
 
-def test_http_server_auth_none(http_server_auth_none):  # noqa: F811
-    create_with_channel(http_server_auth_none)
+def test_http_server_auth_none(
+    http_server_auth_none: str,  # noqa: F811
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    conda_cli(
+        "create",
+        f"--prefix={path_factory()}",
+        "--solver=libmamba",
+        "--json",
+        "--override-channels",
+        f"--channel={http_server_auth_none}",
+        "test-package",
+    )
 
 
-def test_http_server_auth_basic(http_server_auth_basic):  # noqa: F811
-    create_with_channel(http_server_auth_basic)
+def test_http_server_auth_basic(
+    http_server_auth_basic,  # noqa: F811
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    conda_cli(
+        "create",
+        f"--prefix={path_factory()}",
+        "--solver=libmamba",
+        "--json",
+        "--override-channels",
+        f"--channel={http_server_auth_basic}",
+        "test-package",
+    )
 
 
-def test_http_server_auth_basic_email(http_server_auth_basic_email):  # noqa: F811
-    create_with_channel(http_server_auth_basic_email)
+def test_http_server_auth_basic_email(
+    http_server_auth_basic_email,  # noqa: F811
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    conda_cli(
+        "create",
+        f"--prefix={path_factory()}",
+        "--solver=libmamba",
+        "--json",
+        "--override-channels",
+        f"--channel={http_server_auth_basic_email}",
+        "test-package",
+    )
 
 
-def test_http_server_auth_token(http_server_auth_token):  # noqa: F811
-    create_with_channel(http_server_auth_token)
+def test_http_server_auth_token(
+    http_server_auth_token,  # noqa: F811
+    conda_cli: CondaCLIFixture,
+    path_factory: PathFactoryFixture,
+):
+    conda_cli(
+        "create",
+        f"--prefix={path_factory()}",
+        "--solver=libmamba",
+        "--json",
+        "--override-channels",
+        f"--channel={http_server_auth_token}",
+        "test-package",
+    )
 
 
 def test_http_server_auth_token_in_defaults(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Followup to #621 

Completely removes dependency on `conda.testing.integration._get_temp_prefix` which is slated for removal in `conda 25.3`.

Xref https://github.com/conda/conda/issues/14560

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
