### PR TITLE
Adjust getting `restore_free_channel` from `context`

### DIFF
--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -392,7 +392,8 @@ class SolverInputState:
                 yield channel
 
     def maybe_free_channel(self) -> Iterable[Channel]:
-        if context.restore_free_channel:
+        # conda 25.3 removed context.restore_free_channel
+        if getattr(context, "restore_free_channel", False):
             yield Channel.from_url("https://repo.anaconda.com/pkgs/free")
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Xref https://github.com/conda/conda/pull/14647

`context.restore_free_channel` was slated for deprecation in `conda 25.3`

Should CLS deprecate this and bump the minimum conda version?

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
