### PR TITLE
Percent encode spaces in URLs

### DIFF
--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -284,7 +284,6 @@ class LibMambaIndexHelper:
         urls_to_json_path_and_state = self._fetch_repodata_jsons(tuple(urls_to_channel.keys()))
         channel_repo_infos = []
         for url_w_cred, (json_path, state) in urls_to_json_path_and_state.items():
-            print(url_w_cred)
             url_no_token, _ = split_anaconda_token(url_w_cred)
             url_no_cred = remove_auth(url_no_token)
             repo = self._load_repo_info_from_json_path(

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -300,6 +300,9 @@ class LibMambaIndexHelper:
         channels_with_subdirs = []
         for channel in self.channels:
             for url in channel.urls(with_credentials=True, subdirs=self.subdirs):
+                # conda.common.url.path_to_url does not %-encode spaces
+                if url.startswith("file://"):
+                    url = url.replace(" ", "%20")
                 channels_with_subdirs.append(Channel(url))
         for channel in channels_with_subdirs:
             noauth_urls = [

--- a/conda_libmamba_solver/index.py
+++ b/conda_libmamba_solver/index.py
@@ -465,7 +465,8 @@ class LibMambaIndexHelper:
                 for record in package_cache_data.values()
             ]
             repo = self.db.add_repo_from_packages(packages=packages, name=path)
-            path_as_url = path_to_url(path)
+            # path_to_url does not %-encode spaces
+            path_as_url = path_to_url(path).replace(" ", "%20")
             repos.append(
                 _ChannelRepoInfo(
                     channel=None, repo=repo, url_w_cred=path_as_url, url_no_cred=path_as_url

--- a/news/640-percent-encode
+++ b/news/640-percent-encode
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Always percent-encode spaces in `file://` channel URLs. (#640)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

For https://github.com/conda/conda-build/pull/5675.

For some reason, `conda.common.url.path_to_url` only %-encodes [some characters](https://github.com/conda/conda/blob/015d49aa28f1113ddfabcf7ec157dd02aca9ab3c/conda/common/url.py#L120), and the spaces are not included.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
