### PR TITLE
Replace `_supplement_index_with_system` with `Index.system_packages`

### DIFF
--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -72,7 +72,7 @@ from conda.auxlib import NULL
 from conda.base.constants import DepsModifier, UpdateModifier
 from conda.base.context import context
 from conda.common.path import paths_equal
-from conda.core.index import _supplement_index_with_system
+from conda.core.index import Index
 from conda.core.prefix_data import PrefixData
 from conda.core.solve import get_pinned_specs
 from conda.exceptions import PackagesNotFoundError, SpecsConfigurationConflictError
@@ -178,8 +178,7 @@ class SolverInputState:
         self._pinned = {spec.name: spec for spec in get_pinned_specs(prefix)}
         self._aggressive_updates = {spec.name: spec for spec in context.aggressive_update_packages}
 
-        virtual = {}
-        _supplement_index_with_system(virtual)
+        virtual = Index().system_packages
         self._virtual = {record.name: record for record in virtual}
 
         self._requested = {}

--- a/news/654-replace-deprecated-_supplement_index_with_system
+++ b/news/654-replace-deprecated-_supplement_index_with_system
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Replace deprecated `conda.core.index._supplement_index_with_system` with `conda.core.index.Index().system_packages`. (#654 via #655)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda.core.index._supplement_index_with_system` was marked for deprecation in `conda 24.9.0`, since CLS depends on `conda 24.11+` we can simply replace the old implementation in favor of the new implementation.

Resolves #654 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
