### PR TITLE
constrain the torchvision version in test_pytorch_gpu

### DIFF
--- a/news/661-contrain-torchvision-version-in-test_pytorch_gpu
+++ b/news/661-contrain-torchvision-version-in-test_pytorch_gpu
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* constrain the torchvision version in `test_pytorch_gpu`. (#659 via #661)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -614,9 +614,9 @@ def test_satisfied_skip_solve_matchspec(
 @pytest.mark.parametrize(
     "specs",
     (
-        pytest.param(("pytorch", "torchvision"), id="pytorch"),
-        pytest.param(("pytorch>0", "torchvision"), id="pytorch>0"),
-        pytest.param(("pytorch=2", "torchvision"), id="pytorch=2"),
+        pytest.param(("pytorch", "torchvision>0.12"), id="pytorch"),
+        pytest.param(("pytorch>0", "torchvision>0.12"), id="pytorch>0"),
+        pytest.param(("pytorch=2", "torchvision>0.12"), id="pytorch=2"),
     ),
 )
 def test_pytorch_gpu(specs):


### PR DESCRIPTION
### Description

Early versions of the torchvision do not properly constrains the pytorch package they are compatible with. Add a lower bound to avoid these versions.

closes #659 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


