### PR TITLE
record platform in channel avoiding cache

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -9,6 +9,7 @@ This module defines the conda.core.solve.Solver interface and its immediate help
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -640,9 +641,9 @@ class LibMambaSolver(Solver):
         # Signature verification requires channel information _with_ subdir data
         channel = Channel(pkg.channel)
         if not channel.subdir:
-            # conda caches channels created with a call, these should not be mutated.
-            # Create a new channel that is not cached and mutate
-            channel = Channel.from_value(pkg.channel)
+            # conda caches channels
+            # Create a new channel instance that is not cached and mutate
+            channel = copy.deepcopy(channel)
             channel.platform = pkg.platform
 
         return PackageRecord(

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -9,7 +9,6 @@ This module defines the conda.core.solve.Solver interface and its immediate help
 
 from __future__ import annotations
 
-import copy
 import json
 import logging
 import os
@@ -641,10 +640,17 @@ class LibMambaSolver(Solver):
         # Signature verification requires channel information _with_ subdir data
         channel = Channel(pkg.channel)
         if not channel.subdir:
-            # conda caches channels
-            # Create a new channel instance that is not cached and mutate
-            channel = copy.deepcopy(channel)
-            channel.platform = pkg.platform
+            # conda caches channels created using single values
+            # Avoid the cache by using keyword arguments
+            channel = Channel(
+                scheme=channel.scheme,
+                auth=channel.auth,
+                location=channel.location,
+                token=channel.token,
+                name=channel.name,
+                platform=pkg.platform,
+                package_filename=channel.package_filename,
+            )
 
         return PackageRecord(
             name=pkg.name,

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -640,6 +640,9 @@ class LibMambaSolver(Solver):
         # Signature verification requires channel information _with_ subdir data
         channel = Channel(pkg.channel)
         if not channel.subdir:
+            # conda caches channels created with a call, these should not be mutated.
+            # Create a new channel that is not cached and mutate
+            channel = Channel.from_value(pkg.channel)
             channel.platform = pkg.platform
 
         return PackageRecord(

--- a/news/663-record-platform-in-channel-avoiding-cache
+++ b/news/663-record-platform-in-channel-avoiding-cache
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Correctly record channel platform in conda-meta record files (#662 via #663)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/663-record-platform-in-channel-avoiding-cache
+++ b/news/663-record-platform-in-channel-avoiding-cache
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Correctly record channel platform in conda-meta record files (#662 via #663)
+* Correctly record channel platform in conda-meta record files. (#662 via #663)
 
 ### Deprecations
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -651,3 +651,24 @@ def test_pytorch_gpu(specs):
             break
     else:
         raise AssertionError("No pytorch found")
+
+
+def test_channel_subdir_set_correctly(tmp_env: TmpEnvFixture) -> None:
+    """
+    https://github.com/conda/conda-libmamba-solver/issues/662
+    """
+    with tmp_env(
+        "--override-channels",
+        "--channel=conda-forge",
+        "--solver=libmamba",
+        "tzdata",
+        "bzip2",
+    ) as prefix:
+        cm_path: Path = prefix / "conda-meta"
+        for prec_path in cm_path.glob("*.json"):
+            if prec_path.name.startswith("bzip2-"):
+                payload = json.loads(prec_path.read_text())
+                assert not payload["channel"].endswith("noarch")
+            if prec_path.name.startswith("tzdata-"):
+                payload = json.loads(prec_path.read_text())
+                assert payload["channel"].endswith("noarch")


### PR DESCRIPTION
### Description

Record the platform in the PackageRecord channel so that the cache is avoided to prevent updating existing Channel instances.

closes #662 
closes #664 

### Checklist - did you ...

- [x] Add a file to the `news` directory
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
