### PR TITLE
Use `conda.plugins.types.*` imports and ignore warnings from other deprecated modules in `conda`

### DIFF
--- a/conda_libmamba_solver/plugin.py
+++ b/conda_libmamba_solver/plugin.py
@@ -5,19 +5,19 @@
 Entry points for the conda plugin system
 """
 
-from conda import plugins
+from conda.plugins import hookimpl
 
 try:
-    from conda.plugins import CondaSolver
-except ImportError:
     # FUTURE: Use this import only in conda 26.3+
-    from conda.plugins.types import CondaSolver
+    from conda.plugins.types import CondaSolver, CondaSubcommand
+except ImportError:
+    from conda.plugins import CondaSolver, CondaSubcommand
 
 from .repoquery import configure_parser, repoquery
 from .solver import LibMambaSolver
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_solvers():
     """
     The conda plugin hook implementation to load the solver into conda.
@@ -28,9 +28,9 @@ def conda_solvers():
     )
 
 
-@plugins.hookimpl
+@hookimpl
 def conda_subcommands():
-    yield plugins.CondaSubcommand(
+    yield CondaSubcommand(
         name="repoquery",
         summary="Advanced search for repodata.",
         action=repoquery,

--- a/conda_libmamba_solver/plugin.py
+++ b/conda_libmamba_solver/plugin.py
@@ -7,6 +7,11 @@ Entry points for the conda plugin system
 
 from conda import plugins
 
+try:
+    from conda.plugins import CondaSolver
+except ImportError:
+    from conda.plugins.types import CondaSolver
+
 from .repoquery import configure_parser, repoquery
 from .solver import LibMambaSolver
 
@@ -16,7 +21,7 @@ def conda_solvers():
     """
     The conda plugin hook implementation to load the solver into conda.
     """
-    yield plugins.CondaSolver(
+    yield CondaSolver(
         name="libmamba",
         backend=LibMambaSolver,
     )

--- a/conda_libmamba_solver/plugin.py
+++ b/conda_libmamba_solver/plugin.py
@@ -6,7 +6,6 @@ Entry points for the conda plugin system
 """
 
 from conda.plugins import hookimpl
-
 from conda.plugins.types import CondaSolver, CondaSubcommand
 
 from .repoquery import configure_parser, repoquery

--- a/conda_libmamba_solver/plugin.py
+++ b/conda_libmamba_solver/plugin.py
@@ -7,11 +7,7 @@ Entry points for the conda plugin system
 
 from conda.plugins import hookimpl
 
-try:
-    # FUTURE: Use this import only in conda 26.3+
-    from conda.plugins.types import CondaSolver, CondaSubcommand
-except ImportError:
-    from conda.plugins import CondaSolver, CondaSubcommand
+from conda.plugins.types import CondaSolver, CondaSubcommand
 
 from .repoquery import configure_parser, repoquery
 from .solver import LibMambaSolver

--- a/conda_libmamba_solver/plugin.py
+++ b/conda_libmamba_solver/plugin.py
@@ -10,6 +10,7 @@ from conda import plugins
 try:
     from conda.plugins import CondaSolver
 except ImportError:
+    # FUTURE: Use this import only in conda 26.3+
     from conda.plugins.types import CondaSolver
 
 from .repoquery import configure_parser, repoquery

--- a/news/691-conda-solver-type
+++ b/news/691-conda-solver-type
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Import `CondaSolver` from its new location in `conda.plugins.types`. (#691)
+* Import `CondaSolver` from its canonical location in `conda.plugins.types`. (#691)
 
 ### Deprecations
 

--- a/news/691-conda-solver-type
+++ b/news/691-conda-solver-type
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Import `CondaSolver` from its new location in `conda.plugins.types`. (#691)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ filterwarnings = [
   "ignore:`remote_definition`:FutureWarning:argparse",
   "ignore:conda.core.prefix_data.python_record_for_prefix:PendingDeprecationWarning:conda.core.link",
   "ignore:conda.core.prefix_data.PrefixDataType.__call__:PendingDeprecationWarning:conda_libmamba_solver.state",
-  "ignore:conda.env.specs.binstar is deprecated:DeprecationWarning:conda"
+  "ignore:conda.env.specs.binstar is deprecated:PendingDeprecationWarning:conda"
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,12 @@ filterwarnings = [
   "ignore:conda.core.prefix_data.PrefixDataType.__call__:PendingDeprecationWarning:conda_libmamba_solver.state",
   "ignore:conda.env.specs.binstar:DeprecationWarning:conda",
   "ignore:conda.env.specs.binstar:PendingDeprecationWarning:conda",
-  "ignore:conda.plugins.types:DeprecationWarning:conda",
-  "ignore:conda.plugins.types:PendingDeprecationWarning:conda",
+  "ignore:.*conda.plugins.types.*:DeprecationWarning",
+  "ignore:.*conda.plugins.types.*:PendingDeprecationWarning",
   "ignore:conda.trust:DeprecationWarning:conda",
   "ignore:conda.trust:PendingDeprecationWarning:conda",
+  "ignore:conda.core.link.PrefixActions:DeprecationWarning:conda",
+  "ignore:conda.core.link.PrefixActions:PendingDeprecationWarning:conda",
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,12 @@ filterwarnings = [
   "ignore:`remote_definition`:FutureWarning:argparse",
   "ignore:conda.core.prefix_data.python_record_for_prefix:PendingDeprecationWarning:conda.core.link",
   "ignore:conda.core.prefix_data.PrefixDataType.__call__:PendingDeprecationWarning:conda_libmamba_solver.state",
-  "ignore:conda.env.specs.binstar is deprecated:PendingDeprecationWarning:conda"
+  "ignore:conda.env.specs.binstar:DeprecationWarning:conda",
+  "ignore:conda.env.specs.binstar:PendingDeprecationWarning:conda",
+  "ignore:conda.plugins.CondaSubcommand:DeprecationWarning:conda",
+  "ignore:conda.plugins.CondaSubcommand:PendingDeprecationWarning:conda",
+  "ignore:conda.trust:DeprecationWarning:conda",
+  "ignore:conda.trust:PendingDeprecationWarning:conda",
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ filterwarnings = [
   "ignore:`remote_definition`:FutureWarning:argparse",
   "ignore:conda.core.prefix_data.python_record_for_prefix:PendingDeprecationWarning:conda.core.link",
   "ignore:conda.core.prefix_data.PrefixDataType.__call__:PendingDeprecationWarning:conda_libmamba_solver.state",
+  "ignore:conda.env.specs.binstar is deprecated:DeprecationWarning:conda"
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ filterwarnings = [
   "ignore:conda.core.prefix_data.PrefixDataType.__call__:PendingDeprecationWarning:conda_libmamba_solver.state",
   "ignore:conda.env.specs.binstar:DeprecationWarning:conda",
   "ignore:conda.env.specs.binstar:PendingDeprecationWarning:conda",
-  "ignore:conda.plugins.CondaSubcommand:DeprecationWarning:conda",
-  "ignore:conda.plugins.CondaSubcommand:PendingDeprecationWarning:conda",
+  "ignore:conda.plugins.types:DeprecationWarning:conda",
+  "ignore:conda.plugins.types:PendingDeprecationWarning:conda",
   "ignore:conda.trust:DeprecationWarning:conda",
   "ignore:conda.trust:PendingDeprecationWarning:conda",
 ]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Addresses `PendingDeprecationWarning: conda.plugins.CondaSolver is pending deprecation and will be removed in 26.9. Use 'conda.plugins.types.CondaSolver' instead` seen in [conda-build's CI](https://github.com/conda/conda-build/actions/runs/17304471007/job/49123770994?pr=5747).

Introduced in https://github.com/conda/conda/pull/15103.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
