### PR TITLE
sharded repodata model

### DIFF
--- a/conda_libmamba_solver/shards.py
+++ b/conda_libmamba_solver/shards.py
@@ -1,0 +1,338 @@
+"""
+Models for sharded repodata, and to make monolithic repodata look like sharded
+repodata.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING, TypedDict
+from urllib.parse import urljoin
+
+import conda.gateways.repodata as repodata
+import msgpack
+import zstandard
+from conda.base.context import context
+from conda.gateways.connection.session import get_session
+from conda.gateways.repodata import (
+    _add_http_value_to_dict,
+    conda_http_errors,
+)
+from conda.models.records import PackageRecord
+from requests import HTTPError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from conda.core.subdir_data import SubdirData
+    from conda.gateways.repodata import (
+        RepodataCache,
+    )
+    from requests import Response
+
+
+Shard = TypedDict("Shard", {"packages": dict[str, dict], "packages.conda": dict[str, dict]})
+
+
+class RepodataInfo(TypedDict):  # noqa: F811
+    base_url: str  # where packages are stored
+    shards_base_url: str  # where shards are stored
+    subdir: str
+
+
+def maybe_unpack_record(record):
+    """
+    Convert bytes checksums to hex; leave unchanged if already str.
+    """
+    for hash_type in "sha256", "md5":
+        if hash_value := record.get(hash_type):
+            if isinstance(hash_value, bytes):
+                record[hash_type] = hash_value.hex()
+    return record
+
+
+def shard_mentioned_packages(shard: Shard):
+    """
+    Return all dependencies mentioned in a shard, including the shard's own
+    package name.
+
+    Includes virtual packages.
+    """
+    # XXX filter by package name for the possibility of a shard with multiple
+    # (small) packages
+    mentioned = set()
+    for package in (*shard["packages"].values(), *shard["packages.conda"].values()):
+        # to go faster, don't use PackageRecord, record.combined_depends, or
+        # MatchSpec
+        record = PackageRecord(**maybe_unpack_record(package))
+        mentioned.add(record.name)
+        mentioned.update(spec.name for spec in record.combined_depends)
+    return mentioned
+
+
+class ShardsIndex(TypedDict):
+    info: RepodataInfo
+    repodata_version: int
+    removed: list[str]
+    shards: dict[str, bytes]
+
+
+class ShardLike:
+    """
+    Present a "classic" repodata.json as per-package shards.
+    """
+
+    def __init__(self, repodata: dict, url: str = ""):
+        """
+        url: for debugging; not used by this class.
+        """
+        all_packages = {
+            "packages": repodata.pop("packages", {}),
+            "packages.conda": repodata.pop("packages.conda", {}),
+        }
+        self.repodata = repodata  # without packages, packages.conda
+        self.url = url
+
+        shards = defaultdict(lambda: {"packages": {}, "packages.conda": {}})
+
+        for package_group in all_packages:
+            for package, record in all_packages[package_group].items():
+                name = record["name"]
+                shards[name][package_group][package] = record
+
+        # defaultdict behavior no longer wanted
+        self.shards: dict[str, Shard] = dict(shards)  # type: ignore
+
+        # used to write out repodata subset
+        self.visited: dict[str, Shard | None] = {}
+
+    def __repr__(self):
+        return self.url.join(super().__repr__().split(maxsplit=1))
+
+    def __contains__(self, package):
+        return package in self.shards
+
+    def fetch_shard(self, package: str, session) -> Shard:
+        """
+        "Fetch" an individual shard.
+
+        Update self.visited with all not-None packages.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard = self.shards[package]
+        self.visited[package] = shard
+        return shard
+
+    def fetch_shards(self, packages: Iterable[str], session) -> dict[str, Shard]:
+        """
+        Fetch multiple shards in one go.
+
+        Update self.visited with all not-None packages.
+        """
+        return {package: self.fetch_shard(package, session) for package in packages}
+
+    def build_repodata(self):
+        """
+        Return monolithic repodata including all visited shards.
+        """
+        repodata = self.repodata.copy()
+        repodata.update({"packages": {}, "packages.conda": {}})
+        for package, shard in self.visited.items():
+            if shard is None:
+                continue  # recorded visited but not available shards
+            for package_group in ("packages", "packages.conda"):
+                repodata[package_group].update(shard[package_group])
+        return repodata
+
+
+FETCHED_THIS_PROCESS = set()
+
+
+class Shards(ShardLike):
+    def __init__(self, shards_index: ShardsIndex, url: str):
+        """
+        Args:
+            shards_index: raw parsed msgpack dict
+            url: URL of repodata_shards.msgpack.zst
+        """
+        self.shards_index = shards_index
+        self.url = url
+
+        self.repodata = {k: v for k, v in self.shards_index.items() if k not in ("shards",)}
+
+        # used to write out repodata subset
+        self.visited: dict[str, Shard | None] = {}
+
+    def __contains__(self, package):
+        return package in self.packages_index
+
+    @property
+    def packages_index(self):
+        return self.shards_index["shards"]
+
+    def shard_url(self, package: str):
+        """
+        Return shard URL for a given package.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard_name = f"{self.packages_index[package].hex()}.msgpack.zst"
+        # "Individual shards are stored under the URL <shards_base_url><sha256>.msgpack.zst"
+        return urljoin(self.url, f"{self.shards_index['info']['shards_base_url']}{shard_name}")
+
+    def fetch_shard(self, package: str, session) -> Shard:
+        """
+        Fetch an individual shard.
+
+        Raise KeyError if package is not in the index.
+        """
+
+        shard_url = self.shard_url(package)
+        raw_shard = session.get(shard_url).content
+        # ensure it is real msgpack+zstd before inserting into cache
+        shard: Shard = msgpack.loads(zstandard.decompress(raw_shard))  # type: ignore
+        self.visited[package] = shard
+        return shard
+
+    def fetch_shards(self, packages: Iterable[str], session) -> dict[str, Shard]:
+        """
+        Return mapping of *package names* to Shard for given packages.
+        """
+        result = {}
+
+        def fetch(s, url, package):
+            if url in FETCHED_THIS_PROCESS:
+                print("Already got", url)
+                raise RuntimeError("Can't fetch same url twice")
+            FETCHED_THIS_PROCESS.add(url)
+            b1 = time.time_ns()
+            data = s.get(url).content
+            e1 = time.time_ns()
+            print(f"Fetch took {(e1 - b1) / 1e9}s", package, url)
+            return (url, package, data)
+
+        packages = sorted(list(packages))
+        urls_packages = {self.shard_url(package): package for package in packages}
+
+        # beneficial to have thread pool larger than requests' default 10 max
+        # connections per session. There is "context.repodata_threads" but it's
+        # None in the REPL.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            futures = {
+                executor.submit(fetch, session, url, package): (url, package)
+                for url, package in urls_packages.items()
+                if package not in result
+            }
+            # May be inconvenient to cancel a large number of futures. Also, ctrl-C doesn't work reliably out of the box.
+            for future in concurrent.futures.as_completed(futures):
+                print(".", futures[future])
+                url, package, compressed_shard = future.result()
+                # XXX catch exception / 404 / whatever
+                result[package] = msgpack.loads(zstandard.decompress(compressed_shard))
+                try:
+                    package_names = [
+                        p["name"]
+                        for p in (
+                            *result[package]["packages"].values(),
+                            *result[package]["packages.conda"].values(),
+                        )
+                    ]
+                    print("expected", package, "actual", set(package_names))
+                except (AttributeError, KeyError):
+                    print("oops")
+
+        self.visited.update(result)
+
+        return result
+
+
+def repodata_shards(url, cache: RepodataCache) -> bytes:
+    """
+    Fetch shards index with cache.
+
+    Update cache state.
+
+    Return shards data, either newly fetched or from cache.
+    """
+    session = get_session(url)
+
+    state = cache.state
+    headers = {}
+    etag = state.etag
+    last_modified = state.mod
+    if etag:
+        headers["If-None-Match"] = str(etag)
+    if last_modified:
+        headers["If-Modified-Since"] = str(last_modified)
+    filename = "repodata_shards.msgpack.zst"
+
+    with conda_http_errors(url, filename):
+        timeout = (
+            context.remote_connect_timeout_secs,
+            context.remote_read_timeout_secs,
+        )
+        response: Response = session.get(
+            url, headers=headers, proxies=session.proxies, timeout=timeout
+        )
+        response.raise_for_status()
+        response_bytes = response.content
+
+    if response.status_code == 304:
+        # should we save cache-control to state here to put another n
+        # seconds on the "make a remote request" clock and/or touch cache
+        # mtime
+        return cache.cache_path_shards.read_bytes()
+
+    # We no longer add these tags to the large `resp.content` json
+    saved_fields = {repodata.URL_KEY: url}
+    _add_http_value_to_dict(response, "Etag", saved_fields, repodata.ETAG_KEY)
+    _add_http_value_to_dict(response, "Last-Modified", saved_fields, repodata.LAST_MODIFIED_KEY)
+    _add_http_value_to_dict(response, "Cache-Control", saved_fields, repodata.CACHE_CONTROL_KEY)
+
+    state.update(saved_fields)
+
+    # should we return the response and let caller save cache data to state?
+    return response_bytes
+
+
+def fetch_shards(sd: SubdirData) -> Shards | None:
+    """
+    Check a SubdirData's URL for shards.
+    Return shards index bytes from cache or network.
+    Return None if not found; caller should fetch normal repodata.
+    """
+
+    fetch = sd.repo_fetch
+    cache = fetch.repo_cache
+    # cache.load_state() will clear the file on JSONDecodeError but cache.load()
+    # will raise the exception
+    cache.load_state(binary=True)
+    cache_state = cache.state
+
+    if cache_state.should_check_format("shards"):
+        try:
+            # look for shards index
+            shards_index_url = f"{sd.url_w_subdir}/repodata_shards.msgpack.zst"
+            found = repodata_shards(shards_index_url, cache)
+            cache_state.set_has_format("shards", True)
+            # this will also set state["refresh_ns"] = time.time_ns(); we could
+            # call cache.refresh() if we got a 304 instead:
+            cache.save(found)
+
+            # basic parse (move into caller?)
+            shards_index: ShardsIndex = msgpack.loads(zstandard.decompress(found))  # type: ignore
+            shards = Shards(
+                shards_index,
+                shards_index_url,
+            )
+            return shards
+
+        except (HTTPError, repodata.RepodataIsEmpty):
+            # fetch repodata.json / repodata.json.zst instead
+            cache_state.set_has_format("shards", False)
+            cache.refresh(refresh_ns=1)  # expired but not falsy
+
+    return None

--- a/news/696-shards-model
+++ b/news/696-shards-model
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add models for sharded repodata; detect sharded repodata on server. (#696)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_shards.py
+++ b/tests/test_shards.py
@@ -1,0 +1,113 @@
+"""
+Test sharded repodata.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+from conda.base.context import context, reset_context
+from conda.core.subdir_data import SubdirData
+from conda.gateways.connection.session import get_session
+from conda.models.channel import Channel
+
+from conda_libmamba_solver.shards import (
+    ShardLike,
+    fetch_shards,
+    shard_mentioned_packages,
+)
+
+HERE = Path(__file__).parent
+
+
+def package_names(shard):
+    """
+    All package names mentioned in a shard (should be a single package name)
+    """
+    return set(package["name"] for package in shard["packages"].values()) | set(
+        package["name"] for package in shard["packages.conda"].values()
+    )
+
+
+@pytest.fixture
+def conda_no_token(monkeypatch: pytest.MonkeyPatch):
+    """
+    Reset token to avoid being logged in. e.g. the testing channel doesn't understand them.
+    """
+    monkeypatch.setenv("CONDA_TOKEN", "")
+    reset_context()
+
+
+def test_shards(conda_no_token: None):
+    """
+    Test basic shard fetch etc.
+    """
+    channels = [
+        Channel.from_url(f"https://conda.anaconda.org/conda-forge-sharded/{subdir}")
+        for subdir in context.subdirs
+    ]
+
+    # Would eagerly download repodata.json.zst for all channels
+    # helper = LibMambaIndexHelper(
+    #     channels,
+    #     (),  # subdirs
+    #     "repodata.json",
+    #     installed,
+    #     (),  # pkgs_dirs to load packages locally when offline
+    #     in_state=in_state,
+    # )
+
+    # accessing "helper.repos" downloads repodata.json in the traditional way
+    # for all channels:
+    # print(helper.repos)
+
+    subdir_data = SubdirData(channels[0])
+    found = fetch_shards(subdir_data)
+    assert found, f"Shards not found for {channels[0]}"
+
+    for package in found.packages_index:
+        shard_url = found.shard_url(package)
+        assert shard_url.startswith("http")  # or channel url or shards_base_url
+
+    session = get_session(
+        subdir_data.url_w_subdir
+    )  # XXX session could be different based on shards_base_url and different than the packages base_url
+
+    # download or fetch-from-cache a random set of shards
+
+    for package in random.choices([*found.packages_index.keys()], k=16):
+        shard = found.fetch_shard(package, session)
+
+        mentioned_in_shard = shard_mentioned_packages(shard)
+        print(package_names(shard), mentioned_in_shard)
+
+
+def test_shardlike():
+    """
+    ShardLike class presents repodata.json as shards in a way that is suitable
+    for our subsetting algorithm.
+    """
+    repodata = json.loads(
+        (Path(__file__).parent / "data" / "mamba_repo" / "noarch" / "repodata.json").read_text()
+    )
+
+    # make fake packages
+    for n in range(10):
+        for m in range(n):
+            repodata["packages"][f"test{n}{m}.tar.bz2"] = {"name": f"test{n}"}
+            repodata["packages.conda"][f"test{n}{m}.tar.bz2"] = {"name": f"test{n}"}
+
+    as_shards = ShardLike(repodata)
+
+    assert len(as_shards.repodata)
+    assert len(as_shards.shards)
+
+    assert sorted(as_shards.shards["test4"]["packages"].keys()) == [
+        "test40.tar.bz2",
+        "test41.tar.bz2",
+        "test42.tar.bz2",
+        "test43.tar.bz2",
+    ]


### PR DESCRIPTION
Models to present repodata.json and repodata_shards.msgpack.zst in the same way; code to detect shards on the server.

Fix #696 