### PR TITLE
Update reposerver to support os-assigned port

### DIFF
--- a/news/700-improve-test-server
+++ b/news/700-improve-test-server
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Improve repository server in test suite. (#700)

--- a/tests/channel_testing/reposerver.py
+++ b/tests/channel_testing/reposerver.py
@@ -343,11 +343,14 @@ elif args.auth == "basic" or (args.user and args.password):
     handler = BasicAuthHandler
 elif args.auth == "token" or args.token:
     handler = CondaTokenHandler
+else:
+    print("No auth method given.")
+    exit(1)
 
 PORT = args.port
 
 server = HTTPServer(("", PORT), handler)
-print("Server started at localhost:" + str(PORT))
+print("Server started at localhost:" + str(server.server_port))
 try:
     server.serve_forever()
 except Exception as exc:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

One of my favorite tricks is to bind to port 0, and let the OS find an available port.

We use the xprocess log file to find the most recently declared port, but if that's not found then we leave it unchanged. We use the short log file because xprocess doesn't remember the line matching the "our process started up correctly" pattern.

This also updates the test server to accept a path, important if we want to serve generated repodata from a temporary directory.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
