### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Syntax for this file at https://help.github.com/articles/about-codeowners/
+
+*       @conda/conda-maintainers


### PR DESCRIPTION
Following the discussion and approval of the merging of the conda-libmamba-solver team into the conda-maintainers team in https://github.com/conda/conda/issues/15166, we should also make that official and improve the code review experience. 
