### PR TITLE
Remove osx-64 from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -512,7 +512,7 @@ jobs:
       matrix:
         # test lower version (w/ osx-64 & defaults & unit tests) and upper version (w/ osx-arm64 & conda-forge & integration tests)
         arch: [osx-arm64]
-        python-version: ['3.9', '3.13']
+        python-version: ['3.9', '3.12']
         default-channel: [defaults, conda-forge]
         test-type: [conda-libmamba-solver, unit, integration]  # CONDA-LIBMAMBA-SOLVER CHANGE
         test-group: [1, 2, 3]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -511,8 +511,8 @@ jobs:
       fail-fast: false
       matrix:
         # test lower version (w/ osx-64 & defaults & unit tests) and upper version (w/ osx-arm64 & conda-forge & integration tests)
-        arch: [osx-64, osx-arm64]
-        python-version: ['3.9', '3.12']
+        arch: [osx-arm64]
+        python-version: ['3.9', '3.13']
         default-channel: [defaults, conda-forge]
         test-type: [conda-libmamba-solver, unit, integration]  # CONDA-LIBMAMBA-SOLVER CHANGE
         test-group: [1, 2, 3]

--- a/conda_libmamba_solver/state.py
+++ b/conda_libmamba_solver/state.py
@@ -172,7 +172,7 @@ class SolverInputState:
         _pip_interop_enabled: bool | None = None,
     ):
         self.prefix = prefix
-        self._prefix_data = PrefixData(prefix, pip_interop_enabled=_pip_interop_enabled)
+        self._prefix_data = PrefixData(prefix, interoperability=_pip_interop_enabled)
         self._pip_interop_enabled = _pip_interop_enabled
         self._history = History(prefix).get_requested_specs_map()
         self._pinned = {spec.name: spec for spec in get_pinned_specs(prefix)}

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,6 +2,6 @@
 pip
 # run-time
 boltons>=23.0.0
-conda>=24.11
+conda>=25.5
 conda-forge::libmamba>=2.0.0
 conda-forge::libmambapy>=2.0.0

--- a/news/729-remove-osx-64
+++ b/news/729-remove-osx-64
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove osx-64 from test matrix, as osx-64 dependencies are no longer being
+  built. (#729)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "conda >=24.11",
+  "conda >=25.5",
   # "libmambapy >=2",
   "boltons >=23.0.0",
   "msgpack >=1.1.1",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.9
-    - conda >=24.11
+    - conda >=25.5
     - libmambapy >=2.0.0
     - boltons >=23.0.0
     - msgpack-python >=1.1.1

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -68,6 +68,7 @@ def test_python_downgrade_reinstalls_noarch_packages(
             "--solver=libmamba",
             "--override-channels",
             "--channel=conda-forge",
+            "--yes",
             "python=3.9",
         )
         check_call([pip, "--version"])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

As of August 15, [Anaconda is no longer building Intel Mac packages](https://www.anaconda.com/blog/intel-mac-package-support-deprecation).

Remove osx-64 from test matrix as it won't work without those packages.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
