### PR TITLE
remove unused zstandard, requests dependencies

### DIFF
--- a/news/811-compression-zstd
+++ b/news/811-compression-zstd
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove `requests`, `zstandard` dependencies; network access, shards are
+  delegated to conda. (#812)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ dependencies = [
   "conda >=26.5",
   # "libmambapy >=2",
   "boltons >=23.0.0",
-  "requests >=2.28.0,<3",
-  "zstandard >=0.15"
 ]
 dynamic = [
   "version"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ requirements:
     - conda >=26.5
     - libmambapy >=2.0.0,!=2.6.2
     - boltons >=23.0.0
-    - requests >=2.28.0,<3
-    - zstandard >=0.15
 
 test:
   imports:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Instead of using `compression.zstd` in conda-libmamba-solver, it's all delegated to conda now.

Fix #811 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
