### PR TITLE
Ignore CONDA_PACKAGE_EXTENSIONS PendingDeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ filterwarnings = [
   "ignore:conda.trust:PendingDeprecationWarning:conda",
   "ignore:conda.core.link.PrefixActions:DeprecationWarning:conda",
   "ignore:conda.core.link.PrefixActions:PendingDeprecationWarning:conda",
+  "ignore:conda.base.constants.CONDA_PACKAGE_EXTENSIONS:PendingDeprecationWarning",
 ]
 markers = [
   "integration: integration tests that usually require an internet connect",


### PR DESCRIPTION
## Summary

- Add pytest filterwarnings to ignore the `PendingDeprecationWarning` from `conda.base.constants.CONDA_PACKAGE_EXTENSIONS`
- This warning was causing test collection failures across all CI jobs

The deprecation warning message:
```
conda.base.constants.CONDA_PACKAGE_EXTENSIONS is pending deprecation and will be removed in 27.3. Use `conda.base.context.context.plugin_manager.get_package_extractors()` instead.
```

## Test plan

- CI should pass without the deprecation warning causing test failures