### PR TITLE
Show target platform instead of host in cross-platform export

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -209,7 +209,7 @@ class LibMambaSolver(Solver):
         return (
             f"Channels:\n"
             f" - {canonical_names_dashed}\n"
-            f"Platform: {context.subdir}\n"
+            f"Platform: {next(s for s in self.subdirs if s != 'noarch')}\n"
             f"Collecting package metadata ({self._repodata_fn})"
         )
 

--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -209,7 +209,7 @@ class LibMambaSolver(Solver):
         return (
             f"Channels:\n"
             f" - {canonical_names_dashed}\n"
-            f"Platform: {next(s for s in self.subdirs if s != 'noarch')}\n"
+            f"Platform: {next((s for s in self.subdirs if s != 'noarch'), context.subdir)}\n"
             f"Collecting package metadata ({self._repodata_fn})"
         )
 

--- a/news/911-cross-platform-export-display
+++ b/news/911-cross-platform-export-display
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Show the target platform instead of the host platform in the progress
+  message during cross-platform lockfile export. (#911)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -657,47 +657,51 @@ def test_pytorch_gpu(specs):
         raise AssertionError("No pytorch found")
 
 
-def test_cross_platform_spinner_shows_target_platform(tmp_path: Path) -> None:
+_CROSS_PLATFORM_TARGET = "linux-64" if context.subdir != "linux-64" else "win-64"
+
+
+@pytest.mark.parametrize(
+    "subdirs,expected_platform",
+    (
+        pytest.param(
+            (_CROSS_PLATFORM_TARGET, "noarch"),
+            _CROSS_PLATFORM_TARGET,
+            id="cross-platform-target",
+        ),
+        pytest.param(
+            ("noarch",),
+            context.subdir,
+            id="noarch-only-fallback",
+        ),
+    ),
+)
+def test_cross_platform_spinner_message(
+    tmp_path: Path,
+    subdirs: tuple[str, ...],
+    expected_platform: str,
+) -> None:
     """
     https://github.com/conda/conda-libmamba-solver/pull/911
 
-    When ``subdirs`` is set to a non-host platform, the ``Platform:`` line of
-    the metadata-collection spinner message should show the target platform,
-    not the host platform, and must never show ``noarch``.
+    The ``Platform:`` line of the metadata-collection spinner message should
+    show the first non-``noarch`` entry of ``self.subdirs`` (the actual
+    target platform during cross-platform export) and fall back to
+    ``context.subdir`` when ``self.subdirs`` only contains ``noarch``.
     """
     from conda.models.channel import Channel
 
-    target = "linux-64" if context.subdir != "linux-64" else "win-64"
     solver = Solver(
         prefix=tmp_path,
         channels=["conda-forge"],
-        subdirs=(target, "noarch"),
         specs_to_add=["tzdata"],
         command="create",
     )
+    # Assign after construction so the noarch-only case bypasses the
+    # ``next(s for s in self.subdirs if s != "noarch")`` call in ``__init__``.
+    solver.subdirs = subdirs
     message = solver._collect_all_metadata_spinner_message(channels=[Channel("conda-forge")])
-    assert f"Platform: {target}" in message
+    assert f"Platform: {expected_platform}" in message
     assert "Platform: noarch" not in message
-
-
-def test_cross_platform_spinner_falls_back_when_only_noarch(tmp_path: Path) -> None:
-    """
-    https://github.com/conda/conda-libmamba-solver/pull/911
-
-    If ``self.subdirs`` only contains ``noarch`` the spinner message must not
-    raise ``StopIteration``; it should fall back to ``context.subdir``.
-    """
-    from conda.models.channel import Channel
-
-    solver = Solver(
-        prefix=tmp_path,
-        channels=["conda-forge"],
-        specs_to_add=["tzdata"],
-        command="create",
-    )
-    solver.subdirs = ("noarch",)
-    message = solver._collect_all_metadata_spinner_message(channels=[Channel("conda-forge")])
-    assert f"Platform: {context.subdir}" in message
 
 
 def test_channel_subdir_set_correctly(tmp_env: TmpEnvFixture) -> None:

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -657,6 +657,53 @@ def test_pytorch_gpu(specs):
         raise AssertionError("No pytorch found")
 
 
+def test_cross_platform_spinner_shows_target_platform(tmp_path: Path) -> None:
+    """
+    https://github.com/conda/conda-libmamba-solver/pull/911
+
+    When ``subdirs`` is set to a non-host platform, the ``Platform:`` line of
+    the metadata-collection spinner message should show the target platform,
+    not the host platform, and must never show ``noarch``.
+    """
+    from conda.models.channel import Channel
+
+    target = "linux-64" if context.subdir != "linux-64" else "win-64"
+    solver = Solver(
+        prefix=tmp_path,
+        channels=["conda-forge"],
+        subdirs=(target, "noarch"),
+        specs_to_add=["tzdata"],
+        command="create",
+    )
+    message = solver._collect_all_metadata_spinner_message(
+        channels=[Channel("conda-forge")]
+    )
+    assert f"Platform: {target}" in message
+    assert "Platform: noarch" not in message
+
+
+def test_cross_platform_spinner_falls_back_when_only_noarch(tmp_path: Path) -> None:
+    """
+    https://github.com/conda/conda-libmamba-solver/pull/911
+
+    If ``self.subdirs`` only contains ``noarch`` the spinner message must not
+    raise ``StopIteration``; it should fall back to ``context.subdir``.
+    """
+    from conda.models.channel import Channel
+
+    solver = Solver(
+        prefix=tmp_path,
+        channels=["conda-forge"],
+        specs_to_add=["tzdata"],
+        command="create",
+    )
+    solver.subdirs = ("noarch",)
+    message = solver._collect_all_metadata_spinner_message(
+        channels=[Channel("conda-forge")]
+    )
+    assert f"Platform: {context.subdir}" in message
+
+
 def test_channel_subdir_set_correctly(tmp_env: TmpEnvFixture) -> None:
     """
     https://github.com/conda/conda-libmamba-solver/issues/662

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -675,9 +675,7 @@ def test_cross_platform_spinner_shows_target_platform(tmp_path: Path) -> None:
         specs_to_add=["tzdata"],
         command="create",
     )
-    message = solver._collect_all_metadata_spinner_message(
-        channels=[Channel("conda-forge")]
-    )
+    message = solver._collect_all_metadata_spinner_message(channels=[Channel("conda-forge")])
     assert f"Platform: {target}" in message
     assert "Platform: noarch" not in message
 
@@ -698,9 +696,7 @@ def test_cross_platform_spinner_falls_back_when_only_noarch(tmp_path: Path) -> N
         command="create",
     )
     solver.subdirs = ("noarch",)
-    message = solver._collect_all_metadata_spinner_message(
-        channels=[Channel("conda-forge")]
-    )
+    message = solver._collect_all_metadata_spinner_message(channels=[Channel("conda-forge")])
     assert f"Platform: {context.subdir}" in message
 
 


### PR DESCRIPTION
## Summary

- Use `self.subdirs` instead of `context.subdir` in the progress message during cross-platform lockfile export

## Why

When running `conda export --lockfile --platform linux-64` from macOS, the progress spinner displays "Platform: osx-arm64" for every target platform solve instead of the actual target being solved (e.g., "linux-64", "win-64").

The fix uses the same `self.subdirs` pattern already used on line 130 for `init_libmamba_context`, which correctly passes the target platform.

## Verification

One-line change. The existing pattern at line 130 (`next(s for s in self.subdirs if s != "noarch")`) validates this approach.

Fixes conda/conda-libmamba-solver#919