### PR TITLE
Map conda verbosity level to matching libmamba logging level

### DIFF
--- a/conda_libmamba_solver/mamba_utils.py
+++ b/conda_libmamba_solver/mamba_utils.py
@@ -68,7 +68,12 @@ def init_libmamba_context(
     if libmamba_context.output_params.json:
         libmambapy.cancel_json_output(libmamba_context)
     libmamba_context.output_params.quiet = context.quiet
-    libmamba_context.output_params.verbosity = context.verbosity
+    verbosity = context.verbosity
+    # libmambapy only respects 4 log levels. If conda provides
+    # a higher verbosity, set the highest logging verbosity level.
+    if verbosity > 4:
+        verbosity = 4
+    libmamba_context.output_params.verbosity = verbosity
     libmamba_context.set_log_level(
         {
             4: libmambapy.LogLevel.TRACE,
@@ -76,7 +81,7 @@ def init_libmamba_context(
             2: libmambapy.LogLevel.INFO,
             1: libmambapy.LogLevel.WARNING,
             0: libmambapy.LogLevel.ERROR,
-        }[context.verbosity]
+        }[verbosity]
     )
 
     # Prefix params

--- a/news/949-map-verbosity
+++ b/news/949-map-verbosity
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix error when the verbosity level from conda is set higher than 4. (#948 via #949)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_mamba_utils.py
+++ b/tests/test_mamba_utils.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2023 conda
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import pytest
+from conda.base.context import reset_context
+
+from conda_libmamba_solver.mamba_utils import init_libmamba_context
+
+
+@pytest.mark.parametrize(
+    "verbosity,expected_verbosity",
+    (
+        pytest.param("0", 0, id="error level logging"),
+        pytest.param("1", 1, id="warning level logging"),
+        pytest.param("2", 2, id="info level logging"),
+        pytest.param("3", 3, id="debug level logging"),
+        pytest.param("4", 4, id="trace level logging"),
+        pytest.param("5", 4, id="large logging level"),
+    ),
+)
+def test_valid_verbosity(monkeypatch: pytest.MonkeyPatch, verbosity: str, expected_verbosity: int):
+    monkeypatch.setenv("CONDA_VERBOSITY", verbosity)
+    reset_context()
+    libmamba_context = init_libmamba_context()
+    assert libmamba_context.output_params.verbosity == expected_verbosity


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes https://github.com/conda/conda-libmamba-solver/issues/948

With this change conda no longer errors when too many `-v`'s are passed in. For example:

```
$ conda install flask -vvvvv 
. . .

## Package Plan ##

  environment location: /env

  added / updated specs:
    - flask
. . .
```
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
