### PR TITLE
Check for windows specific site-packages path

### DIFF
--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 
+from conda.common.compat import on_win
 from conda.models.channel import Channel
 
 from conda_libmamba_solver.index import LibMambaIndexHelper
@@ -58,6 +59,14 @@ def test_query_search_includes_python_site_packages_path():
     assert prec.name == "python"
     assert prec.version == "3.13.2"
     if python_site_packages_path_support:
-        assert prec.python_site_packages_path == "lib/python3.13t/site-packages"
+        # python_site_packages_path is computed by mamba for every python package.
+        # ref: https://github.com/mamba-org/mamba/blob/2.6.2/libmamba/src/core/query.cpp#L237-L245
+        # Windows vs unix and free-threaded vs not free-threaded will have different results.
+        # ref: https://github.com/mamba-org/mamba/pull/4268/changes
+        # issue ref: https://github.com/mamba-org/mamba/issues/4286
+        if on_win:
+            assert prec.python_site_packages_path == "Lib/site-packages"
+        else:
+            assert prec.python_site_packages_path == "lib/python3.13t/site-packages"
     else:
         assert prec.python_site_packages_path is None

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 
+import pytest
 from conda.common.compat import on_win
 from conda.models.channel import Channel
 
@@ -51,6 +52,7 @@ def test_query_search():
     )
 
 
+@pytest.mark.xfail(on_win, reason="libmambapy bug https://github.com/mamba-org/mamba/issues/4286")
 def test_query_search_includes_python_site_packages_path():
     index = LibMambaIndexHelper(channels=[Channel("conda-forge")], subdirs=("linux-64", "noarch"))
     results = index.search("python=3.13.2=h4724d56_1_cp313t")
@@ -59,14 +61,6 @@ def test_query_search_includes_python_site_packages_path():
     assert prec.name == "python"
     assert prec.version == "3.13.2"
     if python_site_packages_path_support:
-        # python_site_packages_path is computed by mamba for every python package.
-        # ref: https://github.com/mamba-org/mamba/blob/2.6.2/libmamba/src/core/query.cpp#L237-L245
-        # Windows vs unix and free-threaded vs not free-threaded will have different results.
-        # ref: https://github.com/mamba-org/mamba/pull/4268/changes
-        # issue ref: https://github.com/mamba-org/mamba/issues/4286
-        if on_win:
-            assert prec.python_site_packages_path == "Lib/site-packages"
-        else:
-            assert prec.python_site_packages_path == "lib/python3.13t/site-packages"
+        assert prec.python_site_packages_path == "lib/python3.13t/site-packages"
     else:
         assert prec.python_site_packages_path is None


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes windows tests, for example https://github.com/conda/conda-libmamba-solver/actions/runs/26194609277/job/77277180835?pr=949

With the latest release of libmambapy (2.6.2) querying for python packages from windows will inject windows specific `python_site_packages_path` data into results. ref: https://github.com/mamba-org/mamba/issues/4286

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
