### PR TITLE
Add dep constraint -  libmambapy != 2.6.2

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -4,7 +4,7 @@ pip
 boltons>=23.0.0
 conda>=26.1
 conda-forge::libmamba>=2.0.0
-conda-forge::libmambapy>=2.0.0
+conda-forge::libmambapy>=2.0.0,!=2.6.2
 msgpack-python>=1.1.1
 # needed for 'pip install -e conda-libmamba-solver'
 hatchling

--- a/news/959-libmambapy-dep-constraint
+++ b/news/959-libmambapy-dep-constraint
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Adds dependency constraint libmambapy != 2.6.2/ (#959)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.10
     - conda >=26.1
-    - libmambapy >=2.0.0
+    - libmambapy >=2.0.0,!=2.6.2
     - boltons >=23.0.0
     - msgpack-python >=1.1.1
     - requests >=2.28.0,<3


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

supersedes https://github.com/conda/conda-libmamba-solver/pull/950 

This version of libmambapy causes the tests to fail, for example https://github.com/conda/conda-libmamba-solver/actions/runs/26194609277/job/77277180835?pr=949
This is because querying for python packages from windows will inject windows specific python_site_packages_path data into results. ref: https://github.com/mamba-org/mamba/issues/4286.

Note libmambapy 2.7.0 is now available as well :1st_place_medal: 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
