### PR TITLE
Enable infrastructure-managed Dependabot config

### DIFF
--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -43,6 +43,10 @@ conda/infrastructure:
   - src: templates/pull_requests/base.md
     dst: .github/PULL_REQUEST_TEMPLATE.md
 
+  # [optional] dependabot — pick ONE variant
+  - src: templates/dependabot/github-actions-with-pre-commit.yml
+    dst: .github/dependabot.yml
+
   # [optional] rever release files
   # Select one of the following:
   # conda and conda-build release file or

--- a/.github/template-files/config.yml
+++ b/.github/template-files/config.yml
@@ -44,8 +44,14 @@ conda/infrastructure:
     dst: .github/PULL_REQUEST_TEMPLATE.md
 
   # [optional] dependabot — pick ONE variant
+  # - src: templates/dependabot/github-actions.yml
+  #   dst: .github/dependabot.yml
   - src: templates/dependabot/github-actions-with-pre-commit.yml
     dst: .github/dependabot.yml
+  # - src: templates/dependabot/github-actions-with-docs-pip.yml
+  #   dst: .github/dependabot.yml
+  # - src: templates/dependabot/github-actions-full.yml
+  #   dst: .github/dependabot.yml
 
   # [optional] rever release files
   # Select one of the following:

--- a/news/969-infrastructure-dependabot
+++ b/news/969-infrastructure-dependabot
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Enable infrastructure-managed Dependabot configuration via conda/infrastructure templates. (#969)


### PR DESCRIPTION
### Description

Enable infrastructure-managed Dependabot by adding a template-files sync entry for `templates/dependabot/github-actions-with-pre-commit.yml`.

- Variant: `github-actions-with-pre-commit`
- More closely specifies github-actions directory (`/` → `/.github/workflows`)
- Adds pre-commit (monthly)
- Adds cooldown

Expected Dependabot behavior after sync:
- GitHub Actions: weekly, grouped, 7-day cooldown
- pre-commit: monthly, grouped

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~
