### PR TITLE
Do not allow downgrades during conda update

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -380,7 +380,7 @@ class LibMambaSolver(Solver):
 
     def _solver_flags(self, in_state: SolverInputState) -> Request.Flags:
         flags = {
-            "allow_downgrade": True,
+            "allow_downgrade": not in_state.is_updating,
             # About flags.allow_uninstall = True:
             # We used to set this to False on a global basis and then add jobs
             # individually with ALLOW_UNINSTALL=True. Libmamba v2 has a Keep job instead now.

--- a/news/71-update-no-downgrade
+++ b/news/71-update-no-downgrade
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Do not allow package downgrades when running `conda update` (#71, #156)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/976-update-no-downgrade
+++ b/news/976-update-no-downgrade
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Do not allow package downgrades when running `conda update` (#71, #156)
+* Do not allow package downgrades when running `conda update` (#976)
 
 ### Deprecations
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -151,7 +151,6 @@ def test_determinism(tmpdir):
     assert len(set(installed_bokeh_versions)) == 1
 
 
-@pytest.mark.xfail(reason="conda-forge dependency changes?")
 @pytest.mark.parametrize("use_shards", (True, False), ids=("use-shards", "no-use-shards"))
 def test_update_from_latest_not_downgrade(
     tmp_env: TmpEnvFixture,
@@ -180,16 +179,28 @@ def test_update_from_latest_not_downgrade(
         "python",
     ) as prefix:
         original_python = PrefixData(prefix).get("python")
-        conda_cli(
+        out, err, rc = conda_cli(
             "update",
             f"--prefix={prefix}",
             "--solver=libmamba",
             "--override-channels",
             "--channel=conda-forge",
             "python",
+            "--json",
         )
-        update_python = PrefixData(prefix).get("python")
-        assert original_python.version == update_python.version
+        assert rc == 0
+        result = json.loads(out)
+        assert result["success"]
+        if result.get("actions"):
+            # If there were actions, Python MUST NOT be uninstalled, or if uninstalled,
+            # it must be reinstalled with the same version.
+            unlinked_python = next(
+                (r for r in result["actions"]["UNLINK"] if r["name"] == "python"), None
+            )
+            linked_python = next(
+                (r for r in result["actions"]["LINK"] if r["name"] == "python"), None
+            )
+            assert unlinked_python is None or linked_python["version"] == original_python.version
 
 
 @pytest.mark.skipif(not on_linux, reason="Linux only")


### PR DESCRIPTION
### Description

Pulling a change out of #964 to set `allow_downgrade=False` when the subcommand is update, preventing packages from being downgraded to older versions.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [X] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
