### PR TITLE
ci: add workflow concurrency limits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Allow one concurrent deployment
+# Limit each pull request or branch to one concurrent run
 concurrency:
-  group: "pages"
+  group: pages-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Make the documentation concurrency group pull request and branch aware so unrelated documentation runs no longer cancel each other.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist - did you ...

- [x] ~~Add a file to the `news` directory for the next release notes?~~
- [x] ~~Add or update necessary tests?~~
- [x] ~~Add or update outdated documentation?~~