### PR TITLE
ci: use classic solver to update conda-libmamba-solver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
           run-post: false  # skip post cleanup
 
       - name: Update conda-libmamba-solver in base
-        run: conda install -n base --yes "conda-libmamba-solver>=26.4.2"
+        run: conda install -n base --yes --solver=classic "conda-libmamba-solver>=26.4.2"
 
       - name: Conda Install
         working-directory: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -302,7 +302,7 @@ jobs:
           run-post: false  # skip post cleanup
 
       - name: Update conda-libmamba-solver in base
-        run: conda install -n base --yes "conda-libmamba-solver>=26.4.2"
+        run: conda install -n base --yes --solver=classic "conda-libmamba-solver>=26.4.2"
 
       - name: Conda Install
         working-directory: conda
@@ -603,7 +603,7 @@ jobs:
           architecture: ${{ runner.arch }}
 
       - name: Update conda-libmamba-solver in base
-        run: conda install -n base --yes "conda-libmamba-solver>=26.4.2"
+        run: conda install -n base --yes --solver=classic "conda-libmamba-solver>=26.4.2"
 
       - name: Conda Install
         working-directory: conda # CONDA-LIBMAMBA-SOLVER CHANGE


### PR DESCRIPTION
### Description

Run the three `conda-libmamba-solver` base-environment update steps with `--solver=classic`.

The jobs may start with an older `conda-libmamba-solver` build. Using that build to solve its own update can fail before the fixed package is installed, as reported in #597, #982, #984, #988, #990, and #991. Selecting the classic solver isolates this setup step from the installed libmamba solver. The jobs still install and test the current checkout with libmamba afterward.

Follow-up to #926 and #927.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist - did you ...

- [x] ~~Add a file to the `news` directory for the next release notes?~~
- [x] ~~Add or update necessary tests?~~
- [x] ~~Add or update outdated documentation?~~