### PR TITLE
Run solver test suites natively on Windows ARM64

### DIFF
--- a/.github/workflows/pytest-conda-solvers.yml
+++ b/.github/workflows/pytest-conda-solvers.yml
@@ -46,6 +46,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.12', '3.13', '3.14']
+        include:
+          - os: windows-11-arm
+            python-version: '3.14'
+            subdir: win-arm64
 
     steps:
       - name: Checkout conda-libmamba-solver
@@ -69,9 +73,19 @@ jobs:
         with:
           channels: conda-forge
           run-post: false  # skip post cleanup
+          architecture: ${{ matrix.subdir == 'win-arm64' && 'x64' || '' }}
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir == 'win-arm64' && 'win-64' || '' }}
 
       - name: Update conda in base
         run: conda install -n base --yes --override-channels -c conda-forge "conda>=26.5" conda-pypi
+
+      - name: Configure native package channels
+        if: matrix.subdir == 'win-arm64'
+        run: |
+          # Native conda, msgspec, and some dependencies are only in defaults.
+          conda config --append channels defaults
+          conda config --set channel_priority flexible
 
       - name: Install conda dependencies
         # libmamba/libmambapy are not declared in conda-libmamba-solver's
@@ -81,8 +95,11 @@ jobs:
           conda install
           --yes
           --override-channels -c conda-forge
+          ${{ matrix.subdir == 'win-arm64' && '-c defaults' || '' }}
           --file conda-libmamba-solver/dev/requirements.txt
           python=${{ matrix.python-version }}
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
 
       - name: Install pytest-conda-solvers dependencies
         # `conda pypi install -e` does not resolve dependencies, so install
@@ -92,6 +109,7 @@ jobs:
           conda install
           --yes
           --override-channels -c conda-forge
+          ${{ matrix.subdir == 'win-arm64' && '-c defaults' || '' }}
           pytest
           coverage
           fastapi
@@ -104,6 +122,8 @@ jobs:
           typer
           uvicorn
           xdoctest
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
 
       - name: Editable install conda-libmamba-solver and pytest-conda-solvers
         # Run as separate commands: a single `conda pypi install -e A -e B`
@@ -112,6 +132,8 @@ jobs:
         run: |
           conda pypi install --yes -e conda-libmamba-solver
           conda pypi install --yes -e pytest-conda-solvers
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
 
       - name: Conda Info
         run: python -m conda info --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: pwsh
     strategy:
       fail-fast: false
       matrix:
@@ -99,10 +102,21 @@ jobs:
             test-group: 2  # CONDA-LIBMAMBA-SOLVER CHANGE
           - test-type: conda-libmamba-solver  # CONDA-LIBMAMBA-SOLVER CHANGE
             test-group: 3  # CONDA-LIBMAMBA-SOLVER CHANGE
+        include:
+          - runs-on: windows-latest
+            subdir: win-64
+          # conda-forge's native libmambapy builds require Python 3.14.
+          - runs-on: windows-11-arm
+            subdir: win-arm64
+            python-version: '3.14'
+            default-channel: conda-forge
+            test-type: conda-libmamba-solver
+            test-group: 1
     env:
       ErrorActionPreference: Stop  # powershell exit immediately on error
       PYTEST_MARKER: ${{ matrix.test-type == 'unit' && 'not integration and not benchmark' || 'integration and not benchmark' }}
       PYTEST_SPLITS: ${{ matrix.test-type == 'unit' && '2' || '3' }}
+      CONDA_TEST_SUBDIR: ${{ matrix.subdir }}
     steps:
       - name: Checkout conda/conda # CONDA-LIBMAMBA-SOLVER CHANGE
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -136,9 +150,27 @@ jobs:
           # CONDA-LIBMAMBA-SOLVER CHANGE: add conda\
           condarc-file: conda\.github\condarc-${{ matrix.default-channel }}
           run-post: false  # skip post cleanup
+          # Bootstrap with x64 Miniconda until a native installer is available.
+          architecture: x64
+        env:
+          CONDA_SUBDIR: win-64
 
       - name: Update conda-libmamba-solver in base
         run: conda install -n base --yes "conda-libmamba-solver>=26.4.2"
+        env:
+          CONDA_SUBDIR: win-64
+
+      - name: Prepare native test requirements
+        if: matrix.subdir == 'win-arm64'
+        run: |
+          # Native conda and some dependencies are only in defaults.
+          conda config --append channels defaults
+          conda config --set channel_priority flexible
+          # Use the runner's Git until a native conda package is available.
+          (Get-Content conda/tests/requirements-ci.txt) -notmatch '^git(\s|$)' | Set-Content conda/tests/requirements-ci.txt
+          "$(Split-Path (Split-Path (Get-Command git).Source))\usr\bin" | Add-Content $env:GITHUB_PATH
+          # CodSpeed pins pytest-benchmark<5.1 in defaults. This job excludes benchmarks.
+          (Get-Content conda-libmamba-solver/tests/requirements.txt) -notmatch '^pytest-codspeed(\s|$)' | Set-Content conda-libmamba-solver/tests/requirements.txt
 
       - name: Conda Install
         working-directory: conda  # CONDA-LIBMAMBA-SOLVER CHANGE
@@ -153,6 +185,8 @@ jobs:
           --file ..\conda-libmamba-solver\dev\requirements.txt
           ${{ matrix.test-type == 'conda-libmamba-solver' && '--file ..\\conda-libmamba-solver\\tests\\requirements.txt' || '' }}
           python=${{ matrix.python-version }}
+        env:
+          CONDA_SUBDIR: ${{ matrix.subdir }}
 
       # CONDA-LIBMAMBA-SOLVER CHANGE
       - name: Install conda-libmamba-solver
@@ -202,8 +236,10 @@ jobs:
         shell: bash -el {0}
         run: |
           python -m pip install -e ../conda/ --no-deps --no-build-isolation
+          python -m conda init --install
           python -m conda init --all
-          . $CONDA_PREFIX/etc/profile.d/conda.sh
+          . "$CONDA_PREFIX/etc/profile.d/conda.sh"
+          export CONDA_EXE="$CONDA_PREFIX/Scripts/conda.exe"
           python -m pytest -vv ${{ env.PYTEST_CLS_ADDOPTS }} --reruns=${{ env.PYTEST_RERUN_FAILURES_CLS }} --durations=16
       #/ CONDA-LIBMAMBA-SOLVER CHANGE
 

--- a/news/native-windows-arm64-ci
+++ b/news/native-windows-arm64-ci
@@ -1,0 +1,11 @@
+### Enhancements
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other
+
+* Run the solver test suites natively on Windows ARM64 with Python 3.14 (conda/conda#16540).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import os
+import platform
 import shutil
+import sys
+import sysconfig
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from conda.base.context import context, reset_context
+from conda.core.prefix_data import PrefixData
 from conda.testing import http_test_server as http_server_module
 from conda.testing.fixtures import HttpTestServerFixture
+from libmambapy import bindings
+
+import conda_libmamba_solver
 
 from .http_channel_helpers import MAMBA_REPO, TOKEN
 
@@ -22,6 +32,39 @@ pytest_plugins = (
 )
 
 # Shard-related fixtures have been removed (shards module being deprecated)
+
+
+def pytest_report_header():
+    if expected_subdir := os.environ.get("CONDA_TEST_SUBDIR"):
+        assert context.subdir == expected_subdir, context.subdir
+        prefix_data = PrefixData(sys.prefix)
+        for name in ("python", "libmamba", "libmambapy"):
+            assert prefix_data.get(name).subdir == expected_subdir, name
+        assert {record.subdir for record in prefix_data.iter_records()} <= {
+            "noarch",
+            expected_subdir,
+        }
+        assert Path(conda_libmamba_solver.__file__).resolve().parent == (
+            Path(__file__).resolve().parents[1] / "conda_libmamba_solver"
+        )
+        if expected_subdir == "win-arm64":
+            assert platform.machine().lower() == "arm64", platform.machine()
+            assert sysconfig.get_platform() == "win-arm64", sysconfig.get_platform()
+        assert Path(bindings.__file__).resolve().is_relative_to(Path(sys.prefix).resolve())
+
+    return [
+        f"Python platform: {sysconfig.get_platform()}",
+        f"libmambapy extension: {bindings.__file__}",
+        f"conda-libmamba-solver source: {conda_libmamba_solver.__file__}",
+    ]
+
+
+@pytest.fixture
+def historical_python_subdir(monkeypatch):
+    """Solve historical Python regressions with win-64 packages on Windows ARM64."""
+    if context.subdir == "win-arm64":
+        monkeypatch.setenv("CONDA_SUBDIR", "win-64")
+        reset_context()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from urllib.request import urlretrieve
 
 import pytest
+from conda.base.context import context
 from conda.common.compat import on_linux, on_win
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import DryRunExit
@@ -45,7 +46,7 @@ def test_channel_matchspec(conda_cli: CondaCLIFixture, path_factory: PathFactory
         "--override-channels",
         "--channel=defaults",
         "conda-forge::libblas=*=*openblas",
-        "python=3.9",
+        "python=3.14" if context.subdir == "win-arm64" else "python=3.9",
     )
     result = json.loads(stdout)
     assert result["success"] is True
@@ -63,7 +64,8 @@ def test_channels_prefixdata(tmp_env: TmpEnvFixture) -> None:
 
     See https://github.com/conda/conda/issues/11790
     """
-    with tmp_env("conda-forge::xz", "python=3.13", "--solver=libmamba") as prefix:
+    python = "python=3.14" if context.subdir == "win-arm64" else "python=3.13"
+    with tmp_env("conda-forge::xz", python, "--solver=libmamba") as prefix:
         p = conda_subprocess(
             "install",
             "-yp",

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -34,25 +34,25 @@ def test_query_search():
     index = LibMambaIndexHelper(channels=[Channel("conda-forge")])
     for query in (
         "ca-certificates",
-        "ca-certificates =2022.9.24",
-        "ca-certificates >=2022.9.24",
-        "ca-certificates >2022.9.24",
-        "ca-certificates<2022.9.24,>2020",
-        "ca-certificates<=2022.9.24,>2020",
-        "ca-certificates !=2022.9.24,>2020",
+        "ca-certificates =2025.7.9",
+        "ca-certificates >=2025.7.9",
+        "ca-certificates >2025.7.9",
+        "ca-certificates<2025.7.9,>2020",
+        "ca-certificates<=2025.7.9,>2020",
+        "ca-certificates !=2025.7.9,>2020",
         "ca-certificates=*=*_0",
         # TODO: channel specs are accepted but they seem to be ignored by libmambapy.Query!
         # "defaults::ca-certificates",
-        # "defaults::ca-certificates=2022.9.24",
-        # "defaults::ca-certificates[version='>=2022.9.24']",
+        # "defaults::ca-certificates=2025.7.9",
+        # "defaults::ca-certificates[version='>=2025.7.9']",
         # "defaults::ca-certificates[build='*_0']",
     ):
         results = index.search(query)
         assert len(results) > 0, query
 
     assert index.search("ca-certificates=*=*_0") == index.search("ca-certificates[build='*_0']")
-    assert index.search("ca-certificates >=2022.9.24") == index.search(
-        "ca-certificates[version='>=2022.9.24']"
+    assert index.search("ca-certificates >=2025.7.9") == index.search(
+        "ca-certificates[version='>=2025.7.9']"
     )
 
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -106,6 +106,7 @@ def test_conda_build_channel_discovery_preserves_lazy_index(
     assert [channel.base_url for channel in channels] == [second]
 
 
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_python_downgrade_reinstalls_noarch_packages(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
@@ -167,7 +168,7 @@ def test_defaults_specs_work(conda_cli: CondaCLIFixture) -> None:
         "--solver=libmamba",
         "--override-channels",
         "--channel=conda-forge",
-        "python=3.10",
+        "python=3.14" if context.subdir == "win-arm64" else "python=3.10",
         "defaults::libarchive",
         raises=DryRunExit,
     )
@@ -181,6 +182,7 @@ def test_defaults_specs_work(conda_cli: CondaCLIFixture) -> None:
         raise AssertionError("libarchive not found in LINK actions")
 
 
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_determinism(tmpdir):
     "Based on https://github.com/conda/conda-libmamba-solver/issues/75"
     env = os.environ.copy()
@@ -390,6 +392,7 @@ def test_pinned_with_cli_build_string(tmp_env: TmpEnvFixture) -> None:
         assert re.match("PackagesNotFound.*Error", data["exception_name"])
 
 
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_constraining_pin_and_requested():
     env = os.environ.copy()
     env["CONDA_PINNED_PACKAGES"] = "python=3.10"
@@ -507,6 +510,7 @@ def test_ca_certificates_pins(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
 @pytest.mark.skipif(
     context.subdir == "osx-arm64", reason="python=2.7 not available in this platform"
 )
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_python_update_should_not_uninstall_history(
     tmp_env: TmpEnvFixture,
     conda_cli: CondaCLIFixture,
@@ -543,6 +547,7 @@ def test_python_update_should_not_uninstall_history(
             )
 
 
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_python_downgrade_with_pins_removes_truststore(tmp_env: TmpEnvFixture) -> None:
     """
     https://github.com/conda/conda-libmamba-solver/issues/354
@@ -692,7 +697,11 @@ def test_constrains_virtual_package(
 
 def test_urls_are_percent_decoded(tmp_path: Path) -> None:
     solver = Solver(
-        prefix=tmp_path, channels=["conda-forge"], specs_to_add=["x264"], command="create"
+        prefix=tmp_path,
+        channels=["conda-forge"],
+        subdirs=("win-64", "noarch") if context.subdir == "win-arm64" else None,
+        specs_to_add=["x264"],
+        command="create",
     )
     records = solver.solve_final_state()
     for record in records:
@@ -745,18 +754,21 @@ def test_prune_existing_env_dependencies_are_solved(
     """
     https://github.com/conda/conda-libmamba-solver/issues/595
     """
+    python_version, numpy_version = (
+        ("3.14", "2.5.3") if context.subdir == "win-arm64" else ("3.13", "2.2.2")
+    )
     (tmp_path / "env.yml").write_text(
         dedent(
-            """
+            f"""
             channels:
             - conda-forge
             dependencies:
-            - python=3.13
-            - numpy=2.2.2
+            - python={python_version}
+            - numpy={numpy_version}
             """
         )
     )
-    with tmp_env("python=3.13") as prefix:
+    with tmp_env(f"python={python_version}") as prefix:
         out, err, rc = conda_cli(
             "env",
             "update",
@@ -769,7 +781,7 @@ def test_prune_existing_env_dependencies_are_solved(
         print(err, file=sys.stderr)
         assert rc == 0
         PrefixData._cache_.clear()
-        assert PrefixData(prefix).get("python").version.startswith("3.13")
+        assert PrefixData(prefix).get("python").version.startswith(python_version)
         assert PrefixData(prefix).get("numpy")
         out, err, rc = conda_cli("run", f"--prefix={prefix}", "python", "-c", "import numpy")
         print(out)
@@ -902,21 +914,24 @@ def test_channel_subdir_set_correctly(tmp_env: TmpEnvFixture) -> None:
 
 
 def test_python_site_packages_path(tmp_env: TmpEnvFixture) -> None:
+    python_version = "3.14" if context.subdir == "win-arm64" else "3.13"
     with tmp_env(
         "--override-channels",
         "--channel=conda-forge",
         "--solver=libmamba",
-        "python-freethreading=3.13",
+        f"python-freethreading={python_version}",
     ) as prefix:
         PrefixData._cache_.clear()
         prec = PrefixData(prefix).get("python")
         assert prec.name == "python"
-        assert prec.version.startswith("3.13")
+        assert prec.version.startswith(python_version)
         if python_site_packages_path_support:
             if context.subdir.startswith("win"):
                 assert prec.python_site_packages_path == "Lib/site-packages"
             else:
-                assert prec.python_site_packages_path == "lib/python3.13t/site-packages"
+                assert (
+                    prec.python_site_packages_path == f"lib/python{python_version}t/site-packages"
+                )
         else:
             assert prec.python_site_packages_path is None
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -473,17 +473,17 @@ def test_locking_pins(
 
 
 def test_ca_certificates_pins(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture) -> None:
-    ca_certificates_pin = "ca-certificates=2023"
+    ca_certificates_pin = "ca-certificates=2025"
     with tmp_env() as prefix:
         Path(prefix, "conda-meta").mkdir(exist_ok=True)
         Path(prefix, "conda-meta", "pinned").write_text(f"{ca_certificates_pin}\n")
 
         for cli_spec in (
             "ca-certificates",
-            "ca-certificates=2023",
+            "ca-certificates=2025",
             "ca-certificates>0",
-            "ca-certificates<2024",
-            "ca-certificates!=2022",
+            "ca-certificates<2026",
+            "ca-certificates!=2024",
         ):
             out, err, retcode = conda_cli(
                 "install",
@@ -501,7 +501,7 @@ def test_ca_certificates_pins(tmp_env: TmpEnvFixture, conda_cli: CondaCLIFixture
 
             for pkg in data["actions"]["LINK"]:
                 if pkg["name"] == "ca-certificates":
-                    assert pkg["version"].startswith("2023."), cli_spec
+                    assert pkg["version"].startswith("2025."), cli_spec
                     break
             else:
                 raise AssertionError("ca-certificates not found in LINK actions")

--- a/tests/test_workarounds.py
+++ b/tests/test_workarounds.py
@@ -36,6 +36,7 @@ def test_matchspec_star_version():
     )
 
 
+@pytest.mark.usefixtures("historical_python_subdir")
 def test_build_string_filters():
     process = sp.run(
         [


### PR DESCRIPTION
### Description

Add Python 3.14 jobs on `windows-11-arm` to the main test workflow and the shared `pytest-conda-solvers` workflow. Both use native Python and conda-forge's new `libmambapy` 2.9.0 builds. Preserve the existing test matrix.

Use x64 Miniconda to bootstrap the native test environment until a native installer is available. Install dependencies with conda, using conda-forge first and defaults second with flexible channel priority. Defaults supplies native conda 26.7.2 and dependencies that are not yet available from conda-forge. Keep the existing editable source installs.

Run the full solver suite with its existing marker exclusions. Use the runner's Git and omit CodSpeed from the native job because its defaults package requires `pytest-benchmark<5.1`, conflicting with this suite's `>=5.1` requirement. Benchmarks are already excluded from these jobs.

Keep historical Python regression cases by solving for `win-64` where the requested packages were never published for ARM64. The solver process remains native, though subprocesses from those historical environments use x64 emulation. Use native Python and NumPy builds for the other installation tests, and check the test interpreter, installed package platforms, loaded libmambapy extension, and solver source location in the pytest header.

Related to conda/conda#16540 and conda/conda#15448.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
