### PR TITLE
Ensure all not found packages are included from parsed solver error message

### DIFF
--- a/conda_libmamba_solver/solver.py
+++ b/conda_libmamba_solver/solver.py
@@ -794,7 +794,6 @@ class LibMambaSolver(Solver):
                     if "does not exist" in explained_line and "which" not in explained_line:
                         end = explained_words.index("does")
                         not_found.append(cls._matchspec_from_error_str(explained_words[:end]))
-                        break
             else:
                 log.debug("! Problem line not recognized: %s", line)
 

--- a/news/1048-report-all-not-found-packages
+++ b/news/1048-report-all-not-found-packages
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ensure all not found packages are included from parsed solver error message. (#1048)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1005,3 +1005,29 @@ def test_notify_conda_outdated(
     stderr = capsys.readouterr().err
     assert "A newer version of conda exists" in stderr
     assert f"$ {expected_message}" in stderr
+
+
+def test_parse_problems_reports_all_missing_packages() -> None:
+    """
+    Ensure that all not found packages are included in the "not_found"
+    packages report.
+    """
+
+    class FakeUnsolvable:
+        def problems(self, db) -> list[str]:
+            # libmamba v2 emits one "unsupported request" line per missing spec
+            return ["unsupported request", "unsupported request", "unsupported request"]
+
+        def explain_problems(self, db, format) -> str:
+            return dedent(
+                """
+                Cannot install because no candidates were found for:
+                ├─ package-one does not exist
+                ├─ package-two does not exist
+                └─ package-three does not exist
+                """
+            )
+
+    parsed = Solver._parse_problems(FakeUnsolvable(), db=None)
+
+    assert set(parsed["not_found"]) == {"package-one", "package-two", "package-three"}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This pr ensures that all packages that were reported as not found by libmamba get included in the set of "not_found" packages. These will get included in the `PackagesNotFoundError` that is raised if the solve is unsuccessful. 

fixes https://github.com/conda/conda/issues/16461

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-libmamba-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-libmamba-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-libmamba-solver/blob/main/CONTRIBUTING.md -->
